### PR TITLE
Fix bug when modifying the startFrame of a layer

### DIFF
--- a/nin/frontend/app/scripts/controllers/bottom.js
+++ b/nin/frontend/app/scripts/controllers/bottom.js
@@ -21,17 +21,19 @@ angular.module('nin')
     };
 
     $scope.dragResizeLayer = function(event, ui, layer) {
-      console.log(event, ui, layer);
-      socket.sendEvent('set', {
-        id: layer.position,
-        field: 'startFrame',
-        value: ui.position.left
-      });
-      socket.sendEvent('set', {
-        id: layer.position,
-        field: 'endFrame',
-        value: ui.position.left + ui.size.width
-      });
+      if (ui.position.left != layer.startFrame) {
+        socket.sendEvent('set', {
+          id: layer.position,
+          field: 'startFrame',
+          value: ui.position.left
+        });
+      } else {
+        socket.sendEvent('set', {
+          id: layer.position,
+          field: 'endFrame',
+          value: ui.position.left + ui.size.width
+        });
+      }
     };
 
     $interval(function(){


### PR DESCRIPTION
Two events were sent to the server at once, which triggered a double
simultaneous write of layers.json.

This mostly resulted in the endFrame update overwriting the startFrame
update, and sometimes even an extra `]` at the end of the file for some
mysterious reason.
