### PR TITLE
Add path to Makefile

### DIFF
--- a/nin/frontend/Makefile
+++ b/nin/frontend/Makefile
@@ -1,3 +1,6 @@
+PATH := node_module/.bin:$(PATH)
+
+
 .PHONY: all
 all:
 	npm install


### PR DESCRIPTION
To not require people having grunt installed globally, the path
of the local node folder is added.
