### PR TITLE
Add better seeded random function

### DIFF
--- a/nin/dasBoot/Random.js
+++ b/nin/dasBoot/Random.js
@@ -1,0 +1,13 @@
+function Random(seed){
+    var m_w = seed || 123456791;
+    var m_z = 987654321;
+    var mask = 0xffffffff;
+
+    return function random() {
+        m_z = (36969 * (m_z & 65535) + (m_z >> 16)) & mask;
+        m_w = (18000 * (m_w & 65535) + (m_w >> 16)) & mask;
+        var result = ((m_z << 16) + m_w) & mask;
+        result /= 4294967296;
+        return result + 0.5;
+    }
+}


### PR DESCRIPTION
Instead of using
`Math.seedrandom(seed)` which affects the global Math object, use

`var rand = Random(seed)` which returns a unique random object for you
to use. This does not affect the global random method or other instances
of random.
