### PR TITLE
Add option to run nin headlessly

### DIFF
--- a/nin/backend/nin
+++ b/nin/backend/nin
@@ -26,6 +26,15 @@ program
   });
 
 program
+  .command('headless [project]')
+  .description('Run the backend project headlessly')
+  .action(function(project) {
+    project = path.resolve(process.cwd(), project || '');
+    var shouldRunHeadlessly = true;
+    serve.serve(project, shouldRunHeadlessly);
+  });
+
+program
   .command('generate [resource]')
   .description('Generate resources')
   .action(function(toGenerate) {

--- a/nin/backend/serve.js
+++ b/nin/backend/serve.js
@@ -7,7 +7,7 @@ var mkdirp = require('mkdirp');
 var readDir = require('readdir');
 var concat = require('concat-files');
 
-var serve = function(projectPath) {
+var serve = function(projectPath, shouldRunHeadlessly) {
 
   var genPath = p.join(projectPath, '/gen/');
   mkdirp.sync(genPath);
@@ -21,9 +21,11 @@ var serve = function(projectPath) {
   var dasBootDestinationFilePath = p.join(projectPath, '/gen/dasBoot.js');
   concat(dasBootSourceFilePaths, dasBootDestinationFilePath, function() {
     console.log(__dirname);
-    var frontend = express();
-    frontend.use(express.static(__dirname + '/../frontend/dist/'));
-    frontend.listen(8000);
+    if(!shouldRunHeadlessly) {
+      var frontend = express();
+      frontend.use(express.static(__dirname + '/../frontend/dist/'));
+      frontend.listen(8000);
+    }
 
     var sockets = express();
     var sockets_server = require('http').createServer(sockets);
@@ -43,7 +45,11 @@ var serve = function(projectPath) {
     files.use(express.static(projectPath));
     files.listen(9000);
 
-    console.log('serving nin on http://localhost:8000');
+    if(shouldRunHeadlessly) {
+      console.log('running nin headlessly');
+    } else {
+      console.log('serving nin on http://localhost:8000');
+    }
 
   });
 };

--- a/nin/frontend/Gruntfile.js
+++ b/nin/frontend/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
     // The actual grunt server settings
     connect: {
       options: {
-        port: 9000,
+        port: 8000,
         // Change this to '0.0.0.0' to access the server from outside.
         hostname: '0.0.0.0',
         livereload: 8080


### PR DESCRIPTION
This lets users supply a custom frontend if they want, which is useful
for developing the frontend with e.g. grunt.