### PR TITLE
Move makefile inside nin folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-.PHONY: all
-all:
-	cd nin/backend && make
-	cd nin/frontend && make

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In the root folder of your project, execute `nin run`, and visit http://localhos
 
 You will need to have node, npm and bower installed.
 
-Run `make` in the root folder. This is a convenience method that runs `make` in the `frontend` and `backend` folders.
+Run `make` in the nin folder. This is a convenience method that runs `make` in the `frontend` and `backend` folders.
 
 To use grunt, you need to install the command line utility globally, by running `sudo npm install -g grunt-cli`
 

--- a/nin/Makefile
+++ b/nin/Makefile
@@ -1,0 +1,4 @@
+.PHONY: all
+all:
+	cd backend && make
+	cd frontend && make


### PR DESCRIPTION
It makes more sense to have the backend+frontend makefile here, not too far away from the backend and frontend folders themselves.