### PR TITLE
Reload layers when shaders are updated

### DIFF
--- a/nin/backend/socket.js
+++ b/nin/backend/socket.js
@@ -44,13 +44,16 @@ function socket(projectPath) {
       console.log('event!', event, path);
       var pathParts = path.split('/');
       if (event === 'unlink') event = 'delete';
+      if (event == 'addDir') {
+        return;
+      }
       if(pathParts.indexOf('shaders') !== -1) {
         sg.shaderGen(projectPath, function() {
+          conn.send(event, {
+            path: path.slice(projectPath.length)
+          });
         });
       } else {
-        if(event == 'addDir') {
-          return;
-        }
         console.log('Change in project detected: ' + event + ', ' + path)
         conn.send(event, {
           path: path.slice(projectPath.length)

--- a/nin/frontend/app/scripts/controllers/main.js
+++ b/nin/frontend/app/scripts/controllers/main.js
@@ -59,16 +59,31 @@ angular.module('nin')
           CameraController.paths = camerapaths;
           for (var index in CameraController.layers) {
             CameraController.layers[index].parseCameraPath(camerapaths);
-          };
+          }
         });
     }
 
+    function updateShaders(path) {
+      var splitted = path.split('/');
+      var shaderName = splitted[splitted.length - 2];
+      ScriptReloader.reload('//localhost:9000/gen/shaders.js', function() {
+        for (var i=0; i < $scope.layers.length; i++) {
+          var layer = $scope.layers[i];
+          if (layer.shaders && layer.shaders.indexOf(shaderName) !== -1) {
+            demo.lm.refresh(layer.type);
+            demo.lm.update(demo.looper.currentFrame);
+          }
+        }
+        Loader.start(function() {}, function() {});
+      });
+    }
+
     function updateSingleLayer(path) {
+      var splitted = path.split('/');
       ScriptReloader.reload('//localhost:9000/' + path, function() {
-        var splitted = path.split('/');
         var className = splitted[splitted.length - 1].split('.')[0];
         demo.lm.refresh(className);
-        console.log('updateSingleLayer', path);
+        demo.lm.update(demo.looper.currentFrame);
         Loader.start(function() {}, function() {});
       });
     }
@@ -80,6 +95,8 @@ angular.module('nin')
         updateLayers();
       } else if (e.path == '/res/camerapaths.json') {
         updateCamerapaths();
+      } else if (e.path.indexOf('/shaders/') !== -1) {
+        updateShaders(e.path);
       } else {
         updateSingleLayer(e.path);
       }
@@ -92,6 +109,8 @@ angular.module('nin')
         updateLayers();
       } else if (e.path == '/res/camerapaths.json') {
         updateCamerapaths();
+      } else if (e.path.indexOf('/shaders/') !== -1) {
+        updateShaders(e.path);
       } else {
         updateSingleLayer(e.path);
       }


### PR DESCRIPTION
Layers can declare dependencies on shaders in layers.json.
They will then be automatically reloaded when a shader they depend on
changes.
This basically means you get shadertoy-like behavior when using nin with
a text editor on your computer!