### PR TITLE
Refactor file watcher

### DIFF
--- a/nin/backend/package.json
+++ b/nin/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "body-parser": "1.13.2",
-    "chokidar": "0.8.x",
+    "chokidar": "1.0.5",
     "commander": "2.2.x",
     "concat-files": "0.1.x",
     "crc": "2.0.0",

--- a/nin/backend/shadergen.js
+++ b/nin/backend/shadergen.js
@@ -29,7 +29,6 @@ var shaderGen = function(pathPrefix, cb) {
       var tmpData = '';
       var type = '';
       for(var i = 0; i < directories.length; i++) {
-        console.log('compiling shader', directories[i]);
         out += 'SHADERS.' + directories[i] + ' = {';
 
         type = '/uniforms.json';
@@ -63,6 +62,6 @@ var shaderGen = function(pathPrefix, cb) {
       cb();
     });
   });
-}
+};
 
 module.exports = { shaderGen: shaderGen };

--- a/nin/backend/socket.js
+++ b/nin/backend/socket.js
@@ -1,16 +1,19 @@
 var sock = require('sockjs')
-  , chokidar = require('chokidar')
   , fs = require('fs')
-  , sg = require('./shadergen')
   ;
 
 
-function socket(projectPath) {
-  console.log('project path:', projectPath);
-  var echo = sock.createServer();
+function socket(projectPath, onConnectionCallback) {
+  var server = sock.createServer();
   connections = {};
 
-  echo.on('connection', function (conn) {
+  function broadcast(event, data) {
+    for (var id in connections) {
+      connections[id].send(event, data);
+    }
+  }
+
+  server.on('connection', function (conn) {
     connections[conn.id] = conn;
     console.log('connection!');
 
@@ -21,44 +24,13 @@ function socket(projectPath) {
       }));
     };
 
+    if (onConnectionCallback) {
+      onConnectionCallback(conn);
+    }
+
     conn.on('close', function () {
       delete connections[conn.id];
       console.log('lost connection');
-    });
-
-    var watcher = chokidar.watch(
-      [projectPath + '/src/',
-       projectPath + '/res/layers.json',
-       projectPath + '/res/camerapaths.json'], {
-      ignored: /[\/\\]\./,
-      persistent: true,
-      ignoreInitial: false
-    });
-
-
-    /* an empty 'add' handler is needed to
-     * trigger intial callbacks for all files */
-    watcher.on('add', function(){ });
-
-    watcher.on('all', function (event, path) {
-      console.log('event!', event, path);
-      var pathParts = path.split('/');
-      if (event === 'unlink') event = 'delete';
-      if (event == 'addDir') {
-        return;
-      }
-      if(pathParts.indexOf('shaders') !== -1) {
-        sg.shaderGen(projectPath, function() {
-          conn.send(event, {
-            path: path.slice(projectPath.length)
-          });
-        });
-      } else {
-        console.log('Change in project detected: ' + event + ', ' + path)
-        conn.send(event, {
-          path: path.slice(projectPath.length)
-        });
-      }
     });
 
     conn.on('data', function (message) {
@@ -70,12 +42,12 @@ function socket(projectPath) {
           layers[event.id][event.field] = event.value;
           fs.writeFile(projectPath + '/res/layers.json', JSON.stringify(layers, null, '  ') + '\n', function (err) {
 
-          })
-        })
+          });
+        });
       }
     });
-  })
-  return echo;
+  });
+  return {server: server, broadcast: broadcast};
 }
 
-module.exports = {socket: socket};
+module.exports = socket;

--- a/nin/backend/watch.js
+++ b/nin/backend/watch.js
@@ -1,0 +1,74 @@
+var chokidar = require('chokidar')
+  , sg = require('./shadergen')
+  ;
+
+
+function watch(projectPath, cb) {
+  var paths = [];
+  console.log('Project path:', projectPath);
+
+  var watcher = chokidar.watch(
+    ['src/',
+     'res/layers.json',
+     'res/camerapaths.json'], {
+    ignored: [/[\/\\]\./, /\/shaders\//],
+    persistent: true,
+    ignoreInitial: false,
+    cwd: projectPath
+  });
+
+  var logFileChanges = false;
+  watcher.on('ready', function() {
+    logFileChanges = true;
+  });
+
+  /* an empty 'add' handler is needed to
+   * trigger intial callbacks for all files */
+  watcher.on('add', function(){ });
+
+  watcher.on('all', function (event, path) {
+    if (event === 'unlink') event = 'delete';
+    if (event == 'addDir') {
+      return;
+    }
+
+    if (logFileChanges) {
+      console.log('Change in project detected: ' + event + ', ' + path);
+    }
+
+    cb(event, {path: path});
+
+    // Maintain list of files that the frontend will need to load initially
+    if (event === 'add') {
+      paths.push(path);
+    } else if (event === 'delete') {
+      var i = paths.indexOf(path);
+      if (i > -1) {
+        paths.splice(i, 1);
+      }
+    }
+  });
+
+  var shaderWatcher = chokidar.watch('src/shaders/', {
+    ignored: /[\/\\]\./,
+    persistent: true,
+    ignoreInitial: true,
+    cwd: projectPath
+  });
+
+  shaderWatcher.on('all', function(event, path) {
+    if (event === 'add' || event === 'change') {
+      var pathParts = path.split('/');
+      console.log('Recompiling shaders:', pathParts[2]);
+      sg.shaderGen(projectPath, function() {
+        cb(event, {path: path});
+      });
+    }
+  });
+
+  sg.shaderGen(projectPath, function() {});
+
+  return {paths: paths};
+}
+
+module.exports = watch;

--- a/nin/frontend/app/scripts/controllers/main.js
+++ b/nin/frontend/app/scripts/controllers/main.js
@@ -92,9 +92,9 @@
       socket.on('add', function(e) {
         e.path = e.path.replace(/\\/g, '/');
         console.log('add!', e);
-        if(e.path == '/res/layers.json') {
+        if(e.path == 'res/layers.json') {
           updateLayers();
-        } else if (e.path == '/res/camerapaths.json') {
+        } else if (e.path == 'res/camerapaths.json') {
           updateCamerapaths();
         } else if (e.path.indexOf('/shaders/') !== -1) {
           updateShaders(e.path);
@@ -106,9 +106,9 @@
       socket.on('change', function(e) {
         e.path = e.path.replace(/\\/g, '/');
         console.log('change!', e);
-        if(e.path == '/res/layers.json') {
+        if(e.path == 'res/layers.json') {
           updateLayers();
-        } else if (e.path == '/res/camerapaths.json') {
+        } else if (e.path == 'res/camerapaths.json') {
           updateCamerapaths();
         } else if (e.path.indexOf('/shaders/') !== -1) {
           updateShaders(e.path);


### PR DESCRIPTION
Now there's only one file watcher, even though you may have multiple
frontends running.

Shaders are now compiled only once per file change, and the initial
compile is also moved to nin boot, instead of on browser socket
connection.

This should make for less unnecessary recompiling and file watching,
less network traffic, and less spammy terminal output.