### PR TITLE
Add link to online wiki in help menu

### DIFF
--- a/nin/frontend/app/scripts/controllers/main.js
+++ b/nin/frontend/app/scripts/controllers/main.js
@@ -87,7 +87,9 @@
         {
           name: 'Help',
           items: [
-            {name: 'Shortcuts', shortcut: '?', click: function() {}}
+            {name: 'Online wiki', click: function() {
+              window.open('https://github.com/ninjadev/nin/wiki');
+            }}
           ]
         },
       ];


### PR DESCRIPTION
We don't really need the keyboard shortcuts overlay anymore, so this replaces that menu item with something a little bit more useful