### PR TITLE
Remove itsoffset from avconv parameters w/@sigvef

### DIFF
--- a/nin/backend/render.js
+++ b/nin/backend/render.js
@@ -5,7 +5,6 @@ var render = function(projectPath) {
   '-y',
   '-r', '60',
   '-i', projectPath + '/bin/render/%07d.png',
-  '-itsoffset', '-00:00:00.133',
   '-i', projectPath + '/res/music.mp3',
   '-c:v', 'libx264',
   '-c:a', 'copy',


### PR DESCRIPTION
It turns out that itsoffset is not interpreted in the same way by all
codecs/players etc.

Without really understanding everything about avconv, testing with
multiple renders and watching videos played back in slow motion proved
that removing the negative itsoffset yielded the best synced video &
audio.