### PR TITLE
Repair dasBoot concat order

### DIFF
--- a/nin/backend/serve.js
+++ b/nin/backend/serve.js
@@ -15,13 +15,21 @@ var serve = function(projectPath, shouldRunHeadlessly) {
   mkdirp.sync(genPath);
 
   var dasBootSourceDirectoryPath = p.join(__dirname, '/../dasBoot/');
+
+  var dasBootLibSourceFilePaths = readDir.readSync(
+    dasBootSourceDirectoryPath,
+    ['lib/*.js'],
+    readDir.ABSOLUTE_PATHS
+  ).sort();
   var dasBootSourceFilePaths = readDir.readSync(
     dasBootSourceDirectoryPath,
-    ['**.js'],
+    ['*.js'],
     readDir.ABSOLUTE_PATHS
-  );
+  ).sort();
+
   var dasBootDestinationFilePath = p.join(projectPath, '/gen/dasBoot.js');
-  concat(dasBootSourceFilePaths, dasBootDestinationFilePath, function() {
+  concat(dasBootLibSourceFilePaths.concat(dasBootSourceFilePaths),
+         dasBootDestinationFilePath, function() {
     projectSettings.load(projectPath);
 
     console.log(__dirname);


### PR DESCRIPTION
Previously, dasBoot script files were guaranteed to be concat in the
following order: 1) all files from dasBoot/lib in alphabetical order, 2)
all other files from dasBoot in alphabetical order. This was useful
because it let us control dependencies between dasBoot components. This
ordering disappeared in 74bb5aabb30d6892a4c1734e03819ff502dfcac0. This
commit reintroduces this ordering.