### PR TITLE
Fix loadAjax bug where old-format calls would die

### DIFF
--- a/nin/dasBoot/Loader.js
+++ b/nin/dasBoot/Loader.js
@@ -16,12 +16,13 @@ Loader.setRootPath = function(path) {
 };
 
 Loader.prototype.loadAjax = function(filepath, options, callback) {
-  if(!options) {
+  if(!callback) {
     callback = options;
+    options = {};
   }
   this.itemsToAjax.push({
     filepath: filepath,
-    options: options || {},
+    options: options,
     callback: callback
   });
 };


### PR DESCRIPTION
The loadAjax signature was changed from loadAjax(path, callback) to
loadAjax(path, options, callback), and to make things backwards
compatible, the options parameter in the middle is optional, letting old
calls still work. However, there was a bug in the implementation of this
backwards compatibility. This bug is fixed in this commit.