### PR TITLE
Make demo music path user configurable through nin.json

### DIFF
--- a/nin/backend/projectSettings.js
+++ b/nin/backend/projectSettings.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 
 var defaultSettings = {
   music: {
+    path: "res/music.mp3",
     bpm: 110,
     subdivision: 6
   }

--- a/nin/backend/render.js
+++ b/nin/backend/render.js
@@ -1,11 +1,14 @@
-var spawn = require('child_process').spawn;
+var spawn = require('child_process').spawn,
+    path = require('path'),
+    projectSettings = require('./projectSettings');
 
 var render = function(projectPath) {
-  var avconv = spawn('avconv', [
+  var musicPath = path.join(projectPath, projectSettings.load(projectPath).music.path),
+      avconv = spawn('avconv', [
   '-y',
   '-r', '60',
   '-i', projectPath + '/bin/render/%07d.png',
-  '-i', projectPath + '/res/music.mp3',
+  '-i', musicPath,
   '-c:v', 'libx264',
   '-c:a', 'copy',
   '-crf', '16',  

--- a/nin/dasBoot/music.js
+++ b/nin/dasBoot/music.js
@@ -3,7 +3,7 @@ function loadMusic() {
   var _bufferSource;
   var _buffer;
   var _loaded = false;
-  Loader.loadAjax('res/music.mp3', {responseType: 'arraybuffer'}, function(data) {
+  Loader.loadAjax(PROJECT.music.path, {responseType: 'arraybuffer'}, function(data) {
     webAudioContext.decodeAudioData(data, function(buffer) {
       _buffer = buffer;
       _loaded = true;

--- a/nin/frontend/app/scripts/directives/waveform.js
+++ b/nin/frontend/app/scripts/directives/waveform.js
@@ -13,7 +13,7 @@
 
         var waveform;
         var request = new XMLHttpRequest();
-        request.open('GET', '//localhost:9000/res/music.mp3', true);
+        request.open('GET', '//localhost:9000/' + PROJECT.music.path, true);
         request.responseType = 'arraybuffer';
         request.onload = function() {
           context.decodeAudioData(request.response, function(buffer) {


### PR DESCRIPTION
Previously, you had to have a song called music.mp3 in res, now you can
choose yourself, allowing for easy switching if needed.