### PR TITLE
Repair compile for arraybuffer-based music

### DIFF
--- a/nin/dasBoot/Loader.js
+++ b/nin/dasBoot/Loader.js
@@ -88,8 +88,20 @@ Loader.prototype.start = function(onprogress, oncomplete) {
   this.itemsToAjax.forEach(function(item) {
     if(window.FILES) {
       console.log(that.id, item.filepath, FILES[item.filepath] && atob(FILES[item.filepath]).slice(0, 10));
-      item.callback(atob(FILES[item.filepath]));
-      registerAsLoaded(item); 
+      var bytes = atob(FILES[item.filepath])
+      if(item.options.responseType == 'arraybuffer') {
+        var buffer = new ArrayBuffer(bytes.length);
+        var bufferView = new Uint8Array(buffer);
+        for(var i = 0; i < bytes.length; i++) {
+          bufferView[i] = bytes.charCodeAt(i);
+        }
+        item.callback(buffer, function() {
+          registerAsLoaded(item);
+        });
+      } else {
+        item.callback(bytes);
+        registerAsLoaded(item);
+      }
     } else {
       var response = null;
       var request = new XMLHttpRequest();

--- a/nin/dasBoot/music.js
+++ b/nin/dasBoot/music.js
@@ -3,10 +3,11 @@ function loadMusic() {
   var _bufferSource;
   var _buffer;
   var _loaded = false;
-  Loader.loadAjax(PROJECT.music.path, {responseType: 'arraybuffer'}, function(data) {
+  Loader.loadAjax(PROJECT.music.path, {responseType: 'arraybuffer'}, function(data, registerAsLoaded) {
     webAudioContext.decodeAudioData(data, function(buffer) {
       _buffer = buffer;
       _loaded = true;
+      registerAsLoaded();
     });
   });
   var _gainNode = webAudioContext.createGain();


### PR DESCRIPTION
Now, Loader.loadAjax-calls that expect arraybuffer response types must
accept a signalling callback to *their* callback to let the loader know
that the item callback is done preparing whatever it is they need to
prepare. Phew!

This fixes #176.