### PR TITLE
Add lib/ folder support to nin projects

### DIFF
--- a/nin/backend/compile.js
+++ b/nin/backend/compile.js
@@ -37,40 +37,40 @@ function res(projectPath, callback) {
 var compile = function(projectPath, options) {
   console.log('starting to compile');
   function collect(data) {
-      function writeDemoToFile(data, filename) {
-        var binPath = p.join(projectPath, '/bin/');
-        mkdirp(binPath, function() {
-          fs.writeFileSync(projectPath + '/bin/' + filename, data);
-        });
+    function writeDemoToFile(data, filename) {
+      var binPath = p.join(projectPath, '/bin/');
+      mkdirp(binPath, function() {
+        fs.writeFileSync(projectPath + '/bin/' + filename, data);
+      });
+    }
+    if(options.pngCompress) {
+      compress(projectPath, data, function(data) {
+        writeDemoToFile(data, 'demo.png.html');
+        console.log('Successfully compiled demo.png.html!');
+      });
+    } else {
+      var customHtml = '';
+      try {
+        customHtml = fs.readFileSync(projectPath + '/index.html', {encoding: 'utf8'});
+      } catch(e) {
+        customHtml = fs.readFileSync(__dirname + '/index.html', {encoding: 'utf8'});
       }
-      if(options.pngCompress) {
-        compress(projectPath, data, function(data) {
-          writeDemoToFile(data, 'demo.png.html');
-          console.log('Successfully compiled demo.png.html!');
-        });
-      } else {
-        var customHtml = '';
-        try {
-          customHtml = fs.readFileSync(projectPath + '/index.html', {encoding: 'utf8'});
-        } catch(e) {
-          customHtml = fs.readFileSync(__dirname + '/index.html', {encoding: 'utf8'});
-        }
-        var html =
-          customHtml +
-          '<script>' +
-          'GU=1;' + /* hack to make sure GU exisits from the get-go */
-          'BEAN=0;' +
-          'BEAT=false;' +
-          'FRAME_FOR_BEAN=function placeholder(){};' +
-          'BEAN_FOR_FRAME=function placeholder(){};' +
-           data +
-          'var layers = JSON.parse(atob(FILES["res/layers.json"]));' +
-          'var camerapaths = JSON.parse(atob(FILES["res/camerapaths.json"]));' +
-          'demo=bootstrap({layers:layers, camerapaths:camerapaths, onprogress: ONPROGRESS, oncomplete: ONCOMPLETE});' +
-          '</script>';
-        writeDemoToFile(html, 'demo.html') +
-        console.log('Successfully compiled demo.html!');
-      }
+      var html =
+        customHtml +
+        '<script>' +
+        'GU=1;' + /* hack to make sure GU exisits from the get-go */
+        'BEAN=0;' +
+        'BEAT=false;' +
+        'FRAME_FOR_BEAN=function placeholder(){};' +
+        'BEAN_FOR_FRAME=function placeholder(){};' +
+         data +
+        'var layers = JSON.parse(atob(FILES["res/layers.json"]));' +
+        'var camerapaths = JSON.parse(atob(FILES["res/camerapaths.json"]));' +
+        'demo=bootstrap({layers:layers, camerapaths:camerapaths, onprogress: ONPROGRESS, oncomplete: ONCOMPLETE});' +
+        '</script>';
+      writeDemoToFile(html, 'demo.html') +
+      console.log('Successfully compiled demo.html!');
+    }
   }
   res(projectPath, function(data) {
     var genPath = p.join(projectPath, '/gen/');

--- a/nin/backend/compile.js
+++ b/nin/backend/compile.js
@@ -34,30 +34,9 @@ function res(projectPath, callback) {
   });
 }
 
-function lib(projectPath, callback) {
-  console.log('going to walk lib');
-  var walker = walk.walk(projectPath + '/lib/' , {followLinks: false});
-  var files = [];
-  walker.on('file', function(root, stat, next) {
-    var file = fs.readFileSync(root + stat.name);
-    console.log('Incorporating ' + root.slice(13) + stat.name);
-    files.push(file);
-    console.log('OK');
-    next();
-  });
-  walker.on('end', function(){
-    console.log('Merging incorporated files');
-    callback(files.join(';') + ';');
-    console.log('OK');
-  });
-}
-
 var compile = function(projectPath, options) {
   console.log('starting to compile');
-  var compiled = [];
   function collect(data) {
-    compiled.push(data);
-    if (compiled.length == 2) {
       function writeDemoToFile(data, filename) {
         var binPath = p.join(projectPath, '/bin/');
         mkdirp(binPath, function() {
@@ -65,7 +44,7 @@ var compile = function(projectPath, options) {
         });
       }
       if(options.pngCompress) {
-        compress(projectPath, compiled.join(';'), function(data) {
+        compress(projectPath, data, function(data) {
           writeDemoToFile(data, 'demo.png.html');
           console.log('Successfully compiled demo.png.html!');
         });
@@ -84,7 +63,7 @@ var compile = function(projectPath, options) {
           'BEAT=false;' +
           'FRAME_FOR_BEAN=function placeholder(){};' +
           'BEAN_FOR_FRAME=function placeholder(){};' +
-          compiled.join(';') +
+           data +
           'var layers = JSON.parse(atob(FILES["res/layers.json"]));' +
           'var camerapaths = JSON.parse(atob(FILES["res/camerapaths.json"]));' +
           'demo=bootstrap({layers:layers, camerapaths:camerapaths, onprogress: ONPROGRESS, oncomplete: ONCOMPLETE});' +
@@ -92,9 +71,7 @@ var compile = function(projectPath, options) {
         writeDemoToFile(html, 'demo.html') +
         console.log('Successfully compiled demo.html!');
       }
-    }
   }
-  lib(projectPath, collect);
   res(projectPath, function(data) {
     var genPath = p.join(projectPath, '/gen/');
     rmdir(genPath, function(error) {
@@ -103,7 +80,7 @@ var compile = function(projectPath, options) {
         projectSettings.generate(projectPath);
         shaderGen(projectPath, function() {
           console.log('Running closure compiler...');
-          exec('java -jar -Xmx2048m ' + __dirname + '/compiler.jar -O SIMPLE --language_in ECMASCRIPT5 --debug --logging_level INFO ' + __dirname + '/../dasBoot/lib/*.js ' + __dirname + '/../dasBoot/*.js ' + projectPath + '/gen/*.js ' + projectPath + '/src/*.js',
+          exec('java -jar -Xmx2048m ' + __dirname + '/compiler.jar -O SIMPLE --language_in ECMASCRIPT5 --debug --logging_level INFO ' + __dirname + '/../dasBoot/lib/*.js ' + __dirname + '/../dasBoot/*.js ' + projectPath + '/lib/*.js ' + projectPath + '/gen/*.js ' + projectPath + '/src/*.js',
             {encoding: 'binary', maxBuffer: 1024 * 1024 * 1024},
             function(error, stdout, stderr) {
               stderr && console.log(stderr);

--- a/nin/backend/serve.js
+++ b/nin/backend/serve.js
@@ -89,8 +89,9 @@ var serve = function(projectPath, shouldRunHeadlessly) {
     var sockets = express();
     var sockets_server = require('http').createServer(sockets);
     var sock = socket(projectPath, function(conn) {
-      for (var i in watcher.paths) {
-        conn.send('add', eventFromPath({path: watcher.paths[i]}));
+      var sortedPaths = watcher.paths.sort();
+      for (var i in sortedPaths) {
+        conn.send('add', eventFromPath({path: sortedPaths[i]}));
       }
     });
 

--- a/nin/backend/watch.js
+++ b/nin/backend/watch.js
@@ -9,6 +9,7 @@ function watch(projectPath, cb) {
 
   var watcher = chokidar.watch(
     ['src/',
+     'lib/',
      'res/layers.json',
      'res/camerapaths.json'], {
     ignored: [/[\/\\]\./, /\/shaders\//],


### PR DESCRIPTION
lib/ dependencies in src are now properly loaded when using nin. Initial
script loads are now done alphabetically to get a predictable execution
order. Conveniently, lib is before src in the alphabet, so lib files
are loaded first. For compilation, project lib scripts are now added to
closure compiler directly instead of using the old (and broken) manual
concatenation approach.