### PR TITLE
Add disconnected message banner

### DIFF
--- a/nin/frontend/app/scripts/controllers/main.js
+++ b/nin/frontend/app/scripts/controllers/main.js
@@ -268,6 +268,7 @@
 
       socket.onclose = function(e) {
         console.log('nin socket connection closed', e);
+        $scope.disconnected = true;
       };
     });
 })();

--- a/nin/frontend/app/styles/common.less
+++ b/nin/frontend/app/styles/common.less
@@ -533,3 +533,21 @@ input[type=range]:focus::-ms-fill-upper {
   background-color: rgba(255, 255, 255, 0.6);
   border: 2px solid #7f4950;
 }
+
+.disconnect-banner {
+  width: 100%;
+  position: fixed;
+  background: @error-message-bg-color;
+  color: @error-message-text-color;
+  font-size: 16px;
+  height: 48px;
+  padding: 0 15px;
+  line-height: 50px;
+  z-index: 99999999;
+  top: calc(~"50% +  10px");
+  text-align: center;
+  a {
+    color: @error-message-text-color;
+    text-decoration: underline;
+  }
+}

--- a/nin/frontend/app/styles/themes/dark.less
+++ b/nin/frontend/app/styles/themes/dark.less
@@ -40,6 +40,8 @@
 @layer-bar-bg-color-5: @blue-gem;
 @layer-bar-bg-color-6: @daisy-bush;
 @layer-bar-bg-color-7: @arsenic;
+@error-message-bg-color: @night-shadz;
+@error-message-text-color: @text-color;
 
 @logo-path: '/images/nin-dark.png';
 

--- a/nin/frontend/app/styles/themes/light.less
+++ b/nin/frontend/app/styles/themes/light.less
@@ -40,6 +40,8 @@
 @layer-bar-bg-color-5: @emerald;
 @layer-bar-bg-color-6: @red-orange;
 @layer-bar-bg-color-7: @grey-suit;
+@error-message-bg-color: @radical-red;
+@error-message-text-color: @white-smoke;
 
 @logo-path: '/images/nin-light.png';
 

--- a/nin/frontend/app/views/main.html
+++ b/nin/frontend/app/views/main.html
@@ -1,5 +1,13 @@
 <link rel="stylesheet" ng-href="styles/{{ selectedTheme }}.css">
 
+<div
+  class="disconnect-banner"
+  ng-if="disconnected"
+  >
+  Disconnected from the nin backend!
+  Try refreshing, and perhaps restarting <code>nin</code> too.
+</div>
+
 <div menubar menu=menu></div>
 
 <ui-layout options="{ flow : 'row' }" >


### PR DESCRIPTION
This lets the user if the frontend has disconnected from the backend for
some reason. This might happen e.g. if the backend crashes.

![image](https://cloud.githubusercontent.com/assets/578029/15279340/8c3ae172-1b23-11e6-9081-62e6c3e83386.png)
