### PR TITLE
Normalize project root path

### DIFF
--- a/nin/backend/utils.js
+++ b/nin/backend/utils.js
@@ -10,10 +10,10 @@ function findProjectRoot(currentPath) {
         manifest = path.join(base, 'nin.json');
 
     if (fs.existsSync(manifest)) {
-      return base;
+      return base.replace(/\/$/, '');
     }
     up += '../';
-  } while (base != path.sep)
+  } while (base != path.sep);
 }
 
 function findProjectRootOrExit(currentPath) {


### PR DESCRIPTION
Some commands (nin compile, for instance) depend on the projectPath
variable to parse file names.
There was an issue where filenames in FILES[] were written as
'es/filename.ext' (missing the r) when projectPath ended in a trailing
slash.