### PR TITLE
Add checks for allowing playing outside of a loop

### DIFF
--- a/nin/frontend/app/scripts/controllers/bottom.js
+++ b/nin/frontend/app/scripts/controllers/bottom.js
@@ -184,10 +184,14 @@
         $scope.loopEnd = $scope.loopStart + newLoopLength;
       });
 
+      var lastFrame = 0;
       $scope.$watch('currentFrame', function (nextFrame) {
-        if ($scope.loopActive && nextFrame >= $scope.loopEnd) {
+        if ($scope.loopActive && !$scope.demo.music.paused && lastFrame >= $scope.loopStart 
+                              && lastFrame <= $scope.loopEnd && nextFrame >= $scope.loopEnd 
+                              && !(nextFrame >= $scope.loopEnd + 5)) {
           $scope.demo.jumpToFrame($scope.loopStart);
         }
+        lastFrame = nextFrame;
       });
     });
 })();


### PR DESCRIPTION
When setting a loop, currently it is impossible to play outside of this loop. This will only make the loop jump back when the demo is inside of the loop, and allowing for jumps outside of this loop.
