### PR TITLE
Remove keyboard shortcut for rendering frames (shift + R)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ The only rules you need to oblige is that:
 | 3          | set playback rate to 1   |
 | 4          | set playback rate to 2   |
 | 5          | set playback rate to 4   |
-| R          | start rendering frames   |
 
 ## Camera controls
 See [the wiki page](https://github.com/ninjadev/nin/wiki/Camera-Controller) for more information on the Camera Controller.

--- a/nin/frontend/app/scripts/controllers/main.js
+++ b/nin/frontend/app/scripts/controllers/main.js
@@ -105,10 +105,10 @@
         {
           name: 'Render',
           items: [
-            {name: 'Start rendering', shortcut: 'Shift + R', click: function() {
+            {name: 'Start rendering', click: function() {
               commands.startRendering();
             }},
-            {name: 'Stop rendering', shortcut: 'Shift + R', click: function() {
+            {name: 'Stop rendering', click: function() {
               commands.stopRendering();
             }}
           ]

--- a/nin/frontend/app/scripts/directives/keybinding.js
+++ b/nin/frontend/app/scripts/directives/keybinding.js
@@ -100,14 +100,6 @@ angular.module('nin').directive('keybinding', function(commands, render, demo) {
       // 'g'
       commands.setCuePoint();
     },
-    '82': function(e) {
-      // 'R'
-      if(render.isCurrentlyRendering()) {
-        commands.stopRendering();
-      } else {
-        commands.startRendering();
-      }
-    },
     '43': function(e) {
       // '+'
       commands.volumeDelta(0.1);


### PR DESCRIPTION
* stiaje, sigveseb and I have at some point accidentally pressed `shift + R` in nin. That is ever so slightly annoying, because it brings nin to its knee and starts filling up the disk while it is not obvious what is happening.
* Since rendering frames is not something we do often, and we have a menu now, it does not need a keyboard shortcut anymore