### PR TITLE
Tweak playback glow line style

### DIFF
--- a/nin/frontend/app/styles/common.less
+++ b/nin/frontend/app/styles/common.less
@@ -137,21 +137,20 @@ body.fullscreen .bottom {
 }
 
 .glow {
-    width: 20px;
     height: 100%;
-    margin-left: -20px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
 }
 
 .glow.glow-play {
+    width: 10px;
+    margin-left: -9px;
     background: transparent;
-    box-shadow: inset -10px 0px 20px -3px @marker-line-play-glow-color;
-    opacity: 0.7;
+    box-shadow: inset -5px 0px 10px -3px @marker-line-play-glow-color;
 }
 
-.glow.glow-loop {
-    width: 1px;
-    opacity: 0.7;
-    margin-left: 0;
+.glow-visible {
+  opacity: 0.5;
 }
 
 .musiclayer {

--- a/nin/frontend/app/views/bottom-panel.html
+++ b/nin/frontend/app/views/bottom-panel.html
@@ -34,7 +34,10 @@
         height: {{ 50 + 30 * layers.length }}px;
       "
       >
-      <div class="glow glow-play">
+      <div
+        class="glow glow-play"
+        ng-class="{'glow-visible': !main.demo.music.paused}"
+        >
         </div>
     </div>
 


### PR DESCRIPTION
Now it does not leave a glow trail when the demo is not playing. Also,
the effect has been reduced a bit to match the fact that the music
timeline can no longer be zoomed.