### PR TITLE
Lint remaining backend files

### DIFF
--- a/nin/backend/.eslintrc.js
+++ b/nin/backend/.eslintrc.js
@@ -11,7 +11,8 @@ module.exports = {
   "rules": {
     "indent": [
       "error",
-      2
+      2,
+      {"SwitchCase": 1}
     ],
     "linebreak-style": [
       "error",

--- a/nin/backend/compile.js
+++ b/nin/backend/compile.js
@@ -1,52 +1,52 @@
-var chalk = require('chalk');
-var compress = require('./compress').compress;
-var exec = require('child_process').exec;
-var execSync = require('child_process').execSync;
-var fs = require('fs');
-var mkdirp = require('mkdirp');
-var p = require('path');
-var projectSettings = require('./projectSettings');
-var rmdir = require('rimraf');
-var shaderGen = require('./shadergen').shaderGen;
-var utils = require('./utils');
-var walk = require('walk');
+const chalk = require('chalk');
+const compress = require('./compress').compress;
+const exec = require('child_process').exec;
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const p = require('path');
+const projectSettings = require('./projectSettings');
+const rmdir = require('rimraf');
+const shaderGen = require('./shadergen').shaderGen;
+const utils = require('./utils');
+const walk = require('walk');
 
 
 function moveCursorToColumn(col) {
-  return '\033[' + col + 'G';
+  return '\x1B[' + col + 'G';
 }
 
 function renderOK() {
-    console.log(moveCursorToColumn(72) +
-                chalk.grey('[') + chalk.green('OK') + chalk.grey(']'));
+  console.log(moveCursorToColumn(72) +
+    chalk.grey('[') + chalk.green('OK') + chalk.grey(']'));
 }
 
 function renderWarn() {
-    console.log(moveCursorToColumn(70) +
-                chalk.grey('[') + chalk.yellow('WARN') + chalk.grey(']'));
+  console.log(moveCursorToColumn(70) +
+    chalk.grey('[') + chalk.yellow('WARN') + chalk.grey(']'));
 }
 
 function renderError() {
-    console.log(moveCursorToColumn(69) +
-                chalk.grey('[') + chalk.red('ERROR') + chalk.grey(']'));
+  console.log(moveCursorToColumn(69) +
+    chalk.grey('[') + chalk.red('ERROR') + chalk.grey(']'));
 }
 
 function res(projectPath, callback) {
-  var walker = walk.walk(projectPath + '/res/' , {followLinks: false});
-  var files = [];
+  const walker = walk.walk(projectPath + '/res/' , {followLinks: false});
+  const files = [];
   console.log(chalk.yellow('\nCollecting files from res/'));
   walker.on('file', function(root, stat, next) {
 
     /* hacks to ensure slashes in path are correct.
      * TODO: is there a bug in walker that causes
      * these things to happen?  */
-    root += '/'
+    root += '/';
     root = root.replace(/\/\//g, '/');
 
-    var file = fs.readFileSync(root + stat.name);
+    const file = fs.readFileSync(root + stat.name);
     process.stdout.write('- Assimilating ' + chalk.grey('res/') + chalk.magenta(stat.name));
     files.push('FILES[\'' + root.slice(projectPath.length + 1) + stat.name + '\']=\'' +
-               file.toString('base64') + '\'');
+      file.toString('base64') + '\'');
     renderOK();
     next();
   });
@@ -57,22 +57,22 @@ function res(projectPath, callback) {
   });
 }
 
-var compile = function(projectPath, options) {
+const compile = function(projectPath, options) {
   function collect(data) {
     function writeDemoToFile(data, filename) {
-      var binPath = p.join(projectPath, '/bin/');
+      const binPath = p.join(projectPath, '/bin/');
       mkdirp(binPath, function() {
         fs.writeFileSync(projectPath + '/bin/' + filename, data);
       });
     }
 
-    var settings = projectSettings.load(projectPath);
-    var projectVersion = execSync('git rev-parse HEAD');
-    var projectOrigin = execSync('git config --get remote.origin.url');
-    var NINVersion = execSync(`cd ${__dirname} && git rev-parse HEAD`);
-    var NINOrigin = execSync(`cd ${__dirname} && git config --get remote.origin.url`);
+    const settings = projectSettings.load(projectPath);
+    const projectVersion = execSync('git rev-parse HEAD');
+    const projectOrigin = execSync('git config --get remote.origin.url');
+    const NINVersion = execSync(`cd ${__dirname} && git rev-parse HEAD`);
+    const NINOrigin = execSync(`cd ${__dirname} && git config --get remote.origin.url`);
 
-    var metadata = {
+    const metadata = {
       'Title': settings.title,
       'Author': settings.authors.join(', '),
       'Description': settings.description,
@@ -82,26 +82,26 @@ var compile = function(projectPath, options) {
     };
 
     const metadataAsHTMLComments = Object.keys(metadata)
-        .map(key => `<!-- ${key}: ${metadata[key]} -->`)
-        .join('\n');
+      .map(key => `<!-- ${key}: ${metadata[key]} -->`)
+      .join('\n');
 
     const ogTags =
-`<meta property="og:title" content="${utils.unsafeHTMLEscape(metadata.Title)}" />
-<meta property="og:description" content="${utils.unsafeHTMLEscape(metadata.Description)}" />
-<meta property="og:image" content="${metadata.previewImage}" />
-<meta name="author" content="${utils.unsafeHTMLEscape(metadata.Author)}" />`;
+      `<meta property="og:title" content="${utils.unsafeHTMLEscape(metadata.Title)}" />
+      <meta property="og:description" content="${utils.unsafeHTMLEscape(metadata.Description)}" />
+      <meta property="og:image" content="${metadata.previewImage}" />
+      <meta name="author" content="${utils.unsafeHTMLEscape(metadata.Author)}" />`;
 
     const htmlPreamble =
       fs.readFileSync(projectPath + '/index.html', {encoding: 'utf8'})
-        .replace(
-          "NIN_WILL_REPLACE_THIS_TAG_WITH_YOUR_ANALYTICS_ID",
-          settings.googleAnalyticsID)
-        .replace(
-          "NIN_WILL_REPLACE_THIS_TAG_WITH_AUTOGENERATED_COMMENT_TAGS",
-          metadataAsHTMLComments)
-        .replace(
-            "NIN_WILL_REPLACE_THIS_TAG_WITH_AUTOGENERATED_META_TAGS",
-            ogTags);
+      .replace(
+        'NIN_WILL_REPLACE_THIS_TAG_WITH_YOUR_ANALYTICS_ID',
+        settings.googleAnalyticsID)
+      .replace(
+        'NIN_WILL_REPLACE_THIS_TAG_WITH_AUTOGENERATED_COMMENT_TAGS',
+        metadataAsHTMLComments)
+      .replace(
+        'NIN_WILL_REPLACE_THIS_TAG_WITH_AUTOGENERATED_META_TAGS',
+        ogTags);
 
     if(options.pngCompress) {
       process.stdout.write(chalk.yellow('\nCompressing demo to .png.html'));
@@ -110,14 +110,14 @@ var compile = function(projectPath, options) {
         writeDemoToFile(data, 'demo.png.html');
         console.log(chalk.white('\n★ ---------------------------------------- ★'));
         console.log(chalk.white('| ') +
-                    chalk.green('Successfully compiled ') +
-                    chalk.grey('bin/') +
-                    chalk.green('demo.png.html!') +
-                    chalk.white(' |'));
+          chalk.green('Successfully compiled ') +
+            chalk.grey('bin/') +
+            chalk.green('demo.png.html!') +
+            chalk.white(' |'));
         console.log(chalk.white('★ ---------------------------------------- ★\n'));
       });
     } else {
-      var html =
+      const html =
         htmlPreamble +
         '<script>' +
         'GU=1;' + /* hack to make sure GU exisits from the get-go */
@@ -125,18 +125,18 @@ var compile = function(projectPath, options) {
         'BEAT=false;' +
         'FRAME_FOR_BEAN=function placeholder(){};' +
         'BEAN_FOR_FRAME=function placeholder(){};' +
-         data +
+        data +
         'var layers = JSON.parse(atob(FILES["res/layers.json"]));' +
         'demo=bootstrap({layers:layers, onprogress: ONPROGRESS, oncomplete: ONCOMPLETE});' +
         '</script>';
       writeDemoToFile(html, 'demo.html') +
-      process.stdout.write('Successfully compiled demo.html!\n');
+        process.stdout.write('Successfully compiled demo.html!\n');
     }
   }
   res(projectPath, function(data) {
-    var genPath = p.join(projectPath, '/gen/');
-    rmdir(genPath, function(error) {
-      mkdirp(genPath, function(error) {
+    const genPath = p.join(projectPath, '/gen/');
+    rmdir(genPath, function() {
+      mkdirp(genPath, function() {
         fs.writeFileSync(projectPath + '/gen/files.js', new Buffer(data));
         projectSettings.generate(projectPath);
         shaderGen(projectPath, function() {

--- a/nin/backend/generate/generate.js
+++ b/nin/backend/generate/generate.js
@@ -1,22 +1,22 @@
-var fs = require('fs'),
-    path = require('path'),
-    utils = require('../utils'),
-    graph = require('../graph'),
-    mkdirp = require('mkdirp');
+const fs = require('fs');
+const path = require('path');
+const utils = require('../utils');
+const graph = require('../graph');
+const mkdirp = require('mkdirp');
 
-var generate = function(projectRoot, type, name, options) {
+const generate = function(projectRoot, type, name, options) {
   if (type == '' || name == '') {
     return;
   }
 
-  var camelizedName = utils.camelize(name);
+  const camelizedName = utils.camelize(name);
 
   switch (type) {
     case 'node':
       generateLayer(camelizedName,
-          'TemplateNode.js',
-          [[/TemplateNode/g, camelizedName]],
-          projectRoot);
+        'TemplateNode.js',
+        [[/TemplateNode/g, camelizedName]],
+        projectRoot);
 
       graph.transform(projectRoot, function(g) {
         g.push(Object.assign({
@@ -36,14 +36,14 @@ var generate = function(projectRoot, type, name, options) {
       generateShader(camelizedName, projectRoot);
       break;
 
-    case 'shaderWithLayer':
-      var shaderLayerName = camelizedName + 'Layer';
+    case 'shaderWithLayer': {
+      const shaderLayerName = camelizedName + 'Layer';
 
       generateShader(camelizedName, projectRoot);
       generateLayer(shaderLayerName, 'TemplateShaderLayer.js',
-          [[/TemplateLayer/g, shaderLayerName],
-           [/TemplateShader/g, camelizedName]],
-          projectRoot);
+        [[/TemplateLayer/g, shaderLayerName],
+          [/TemplateShader/g, camelizedName]],
+        projectRoot);
 
       layers.add(projectRoot, {
         displayName: name,
@@ -57,29 +57,30 @@ var generate = function(projectRoot, type, name, options) {
         }
       });
       break;
+    }
 
     default:
       process.stderr.write('Attempted to generate resource without generator:', type, '\n');
   }
 };
 
-var generateShader = function(shaderName, projectRoot) {
-  var targetShaderPath = path.join(projectRoot, 'src', 'shaders', shaderName),
-      templateShaderPath = path.join(__dirname, 'templateShader');
+const generateShader = function(shaderName, projectRoot) {
+  const targetShaderPath = path.join(projectRoot, 'src', 'shaders', shaderName),
+    templateShaderPath = path.join(__dirname, 'templateShader');
 
   mkdirp.sync(targetShaderPath);
   fs.readdirSync(templateShaderPath).forEach(function (fileName) {
-    var from = path.join(templateShaderPath, fileName),
-        to = path.join(targetShaderPath, fileName);
+    const from = path.join(templateShaderPath, fileName),
+      to = path.join(targetShaderPath, fileName);
     fs.createReadStream(from).pipe(fs.createWriteStream(to));
   });
 
   process.stdout.write('Generated shader ' + shaderName + '\n');
 };
 
-var generateLayer = function(layerName, templateFile, filters, projectRoot) {
-  var layerFileName = layerName + '.js';
-  var newLayer = path.join(projectRoot, 'src', layerFileName);
+const generateLayer = function(layerName, templateFile, filters, projectRoot) {
+  const layerFileName = layerName + '.js';
+  const newLayer = path.join(projectRoot, 'src', layerFileName);
 
   mkdirp.sync(path.join(projectRoot, 'src'));
   if (fs.existsSync(newLayer)) {
@@ -88,9 +89,9 @@ var generateLayer = function(layerName, templateFile, filters, projectRoot) {
   }
 
   templateFile = path.join(__dirname, templateFile);
-  var templateLayer = fs.readFileSync(templateFile, 'utf-8');
+  let templateLayer = fs.readFileSync(templateFile, 'utf-8');
 
-  for (var i=0; i<filters.length; i++) {
+  for (let i=0; i<filters.length; i++) {
     templateLayer = templateLayer.replace(filters[i][0], filters[i][1]);
   }
 
@@ -99,4 +100,4 @@ var generateLayer = function(layerName, templateFile, filters, projectRoot) {
   process.stdout.write('Generated layer ' + layerFileName + '\n');
 };
 
-module.exports = {generate: generate};
+module.exports = {generate};

--- a/nin/backend/socket.js
+++ b/nin/backend/socket.js
@@ -37,24 +37,24 @@ function socket(projectPath, onConnectionCallback) {
     conn.on('data', function (message) {
       let event = JSON.parse(message);
       switch (event.type) {
-      case 'set':
-        // TODO: Untested, nothing uses this yet
-        graph.transform(projectPath, function(g) {
-          const index = g.findIndex(nodeInfo => nodeInfo.id == event.data.id);
-          for (const key in event.data.fields) {
-            g[index][key] = event.data.fields[key];
-          }
-        },
-        function(err) {
-          if (err) {
-            console.log(err);
-          }
-        });
-        break;
+        case 'set':
+          // TODO: Untested, nothing uses this yet
+          graph.transform(projectPath, function(g) {
+            const index = g.findIndex(nodeInfo => nodeInfo.id == event.data.id);
+            for (const key in event.data.fields) {
+              g[index][key] = event.data.fields[key];
+            }
+          },
+            function(err) {
+              if (err) {
+                console.log(err);
+              }
+            });
+          break;
 
-      case 'generate':
-        generate.generate(projectPath, event.data.type, event.data.name);
-        break;
+        case 'generate':
+          generate.generate(projectPath, event.data.type, event.data.name);
+          break;
       }
     });
   });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "walk": "2.3.9"
   },
   "scripts": {
-    "lint": "eslint nin/backend/ || true"
+    "lint": "cd nin/backend && eslint . || true"
   },
   "bin": {
     "nin": "./nin/backend/nin"


### PR DESCRIPTION
The lint command in package.json is updated so that the eslint runs with
backend as cwd. This ensures that it loads the correct .eslintignore

Templates in the generate folder are ignored since they're not strictly
part of the backend, but templates for user projects.

Also, one lint error remains, but it's there because the feature is
still broken so I figured it serves as a nice reminder to fix the
feature.