### PR TITLE
Make nin init take directory, init as git repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ nin is Ninjadev's internal demo tool. It is a tool for easing development of bro
 This project has a node backend that keeps track of all files and compiles files as they are edited.
 The frontend of this project is written in Angular and displays among other the layers that the demo consists of.
 
+# User manual
+
 ## Installing nin
 
 To install nin simply run the command `npm install -g ninjadev-nin`.
-
-## Requirements
-
 This projects requires node version `7.1.0` or newer.
+
+## Getting started
+
+Running `nin new <dirname>` will create the specified directory and initialize a new nin project inside.
+Running `nin run` inside the newly created project will make it accessible on http://localhost:8000.
 
 ## nin is now node-based!
 
@@ -24,15 +28,16 @@ Here is a list of gotchas to watch out for if you are used to layer-based nin:
 
 - Changing res/graph.json does *not* trigger updates in a running nin instance.
 
-## How it works
-Create a new project with a structure like the one seen in the directory `example-project`.
-It may be stored anywhere on your disk.
-In the root folder of your project, execute `nin run`, and visit http://localhost:8000 in your browser to use nin.
+## Compiling
+The `nin compile` command will create a single file `bin/demo.png.html` that contains all the code and resources of your demo.
+Base64 and PNG compression magic is used to achieve this.
+To compile without PNG compression, use `nin compile --no-png-compression`.
+That will yield a slightly larger file, but more browsers will be able to run it.
 
-### Compiling
-The `nin compile` command will create a single file `bin/demo.png.html` that contains all the code and resources of your demo. Base64 and PNG compression magic is used to achieve this. To compile without PNG compression, use `nin compile --no-png-compression`. That will yield a slightly larger file, but more browsers will be able to run it.
+You must have java installed for the `nin compile` command to work.
 
-### Rendering to video
+## Rendering to video
+
 1. `nin run`.
 1. Open nin in your browser, navigate to the frame you want to render from, and press R. This will start dumping single frames as numbered .PNGs in `bin/render/`  in your project folder.
 1. Refresh etc every time WebGL crashes.
@@ -42,10 +47,9 @@ The `nin compile` command will create a single file `bin/demo.png.html` that con
 Each frame will take up to around 4MB on disk, and the finished .mp4 will be on the order of 1GB when rendered, so make sure you have enough disk space.
 Expect to render maybe a frame or two per second.
 
-### Start screen
-In the compiled result, you can have a start screen that is shown while the demo is being loaded. When compiling, nin will look for an `index.html` file in the root folder of your demo, and use that as start screen. JavaScript functions `ONPROGRESS` and `ONCOMPLETE` should be implemented in `index.html`. After `ONCOMPLETE` is called, `demo.start()` may be called. `index.html` should not include `</body>` or `</html>`.
+# Developer manual
 
-## Development Setup
+## Setup
 
 You will need to have node, yarn and webpack installed.
 Yarn installation guide is available [here](https://yarnpkg.com/en/docs/install).
@@ -55,13 +59,11 @@ Install webpack by running `npm install -g webpack`.
 Running `make` in the nin folder will build and compile the entire project.
 Running `npm link` will add nin to your node binaries path, making it available globally.
 
-You must have java installed for the `nin compile` command to work.
+# Developing
 
-## Developing
-
-When developing on nin, it can be useful to run the backend and frontend separately.
-Instead of executing `nin run` in your project folder, run `nin headless` which will start the backend as usual, but without a frontend connected.
-This allows you to serve a development version of the frontend by running `grunt serve` in the frontend folder.
+First, run `nin run` inside your project.
+If you wish to develop on the frontend, running `make run` inside `nin/frontend/` makes webpack rebuild the frontend on file change.
+You only need to rerun `nin run` if you change files in either `nin/dasBoot` or `nin/backend`.
 
 ## Linting
 

--- a/nin/backend/blank-project/.gitignore
+++ b/nin/backend/blank-project/.gitignore
@@ -1,0 +1,5 @@
+bin/
+gen/
+.*.swp
+.DS_STORE
+.idea

--- a/nin/backend/generate/generate.js
+++ b/nin/backend/generate/generate.js
@@ -27,7 +27,7 @@ const generate = function(projectRoot, type, name, options) {
         if (err) {
           console.error(err);
         } else {
-          console.log('Added ' + name + ' to graph.json');
+          console.log(`-> added ${name} to graph.json`);
         }
       });
       break;
@@ -53,7 +53,7 @@ const generate = function(projectRoot, type, name, options) {
         if (err) {
           console.error(err);
         } else {
-          console.log('Added ' + shaderLayerName + ' to layers.json');
+          console.log(`-> added ${shaderLayerName} to layers.json`);
         }
       });
       break;
@@ -75,7 +75,7 @@ const generateShader = function(shaderName, projectRoot) {
     fs.createReadStream(from).pipe(fs.createWriteStream(to));
   });
 
-  process.stdout.write('Generated shader ' + shaderName + '\n');
+  console.log(`-> added ${shaderName} to src`);
 };
 
 const generateLayer = function(layerName, templateFile, filters, projectRoot) {
@@ -96,8 +96,7 @@ const generateLayer = function(layerName, templateFile, filters, projectRoot) {
   }
 
   fs.writeFileSync(newLayer, templateLayer);
-
-  process.stdout.write('Generated layer ' + layerFileName + '\n');
+  console.log(`-> added ${layerFileName} to src`);
 };
 
 module.exports = {generate};

--- a/nin/backend/init.js
+++ b/nin/backend/init.js
@@ -32,7 +32,7 @@ function init(dirname) {
           }
         });
         projectSettings.init(projectPath);
-        console.log(chalk.green('This directory is now a nin project. Do'),
+        console.log(chalk.green(`${projectPath} is now a nin project. Run`),
                     chalk.cyan('nin run'),
                     chalk.green('to get started!'));
       }

--- a/nin/backend/init.js
+++ b/nin/backend/init.js
@@ -1,19 +1,28 @@
-let chalk = require('chalk');
-let child_process = require('child_process');
-let generate = require('./generate/generate');
-let path = require('path');
-let projectSettings = require('./projectSettings');
-let utils = require('./utils');
-let glob = require('glob');
+const chalk = require('chalk');
+const child_process = require('child_process');
+const fs = require('fs');
+const generate = require('./generate/generate');
+const glob = require('glob');
+const path = require('path');
+const projectSettings = require('./projectSettings');
 
 
-function init(projectPath) {
-  let root = utils.findProjectRoot(projectPath);
-  if(root) {
-    console.log(chalk.red('Error: this directory is already a nin project.'));
-    process.exit(1); 
+function init(dirname) {
+  const projectPath = path.join(process.cwd(), dirname);
+  try {
+    fs.mkdirSync(projectPath);
+  } catch (e) {
+    console.error(chalk.red(e));
+    process.exit(1);
   }
+  child_process.execSync(
+      `git init ${projectPath}`,
+      {stdio: 'inherit'});
+
   glob(path.join(__dirname, 'blank-project/*'), function(error, files) {
+    // As globs don't expand to include dotfiles,
+    // we need to add the .gitignore manually
+    files.push(path.join(__dirname, 'blank-project/.gitignore'));
     let numberOfRemainingFiles = files.length;
     function end() {
       if(--numberOfRemainingFiles == 0) {

--- a/nin/backend/init.js
+++ b/nin/backend/init.js
@@ -19,10 +19,7 @@ function init(dirname) {
       `git init ${projectPath}`,
       {stdio: 'inherit'});
 
-  glob(path.join(__dirname, 'blank-project/*'), function(error, files) {
-    // As globs don't expand to include dotfiles,
-    // we need to add the .gitignore manually
-    files.push(path.join(__dirname, 'blank-project/.gitignore'));
+  glob(path.join(__dirname, 'blank-project/*'), {dot: true}, function(error, files) {
     let numberOfRemainingFiles = files.length;
     function end() {
       if(--numberOfRemainingFiles == 0) {
@@ -34,7 +31,7 @@ function init(dirname) {
         projectSettings.init(projectPath);
         console.log(chalk.green(`${projectPath} is now a nin project. Run`),
                     chalk.cyan('nin run'),
-                    chalk.green('to get started!'));
+                    chalk.green('inside to serve your project!'));
       }
     }
     files.map(function(file) {

--- a/nin/backend/nin
+++ b/nin/backend/nin
@@ -17,7 +17,7 @@ program.Command.prototype.outputHelp = function() {
 };
 
 program
-  .command('init')
+  .command('new')
   .description('Turn the current directory into a nin project')
   .arguments('<dirname>', 'Where to create the new project')
   .action(function(dirname) {

--- a/nin/backend/nin
+++ b/nin/backend/nin
@@ -19,8 +19,9 @@ program.Command.prototype.outputHelp = function() {
 program
   .command('init')
   .description('Turn the current directory into a nin project')
-  .action(function(options) {
-    init.init(process.cwd());
+  .arguments('<dirname>', 'Where to create the new project')
+  .action(function(dirname) {
+    init.init(dirname);
   });
 
 program

--- a/nin/backend/projectSettings.js
+++ b/nin/backend/projectSettings.js
@@ -1,6 +1,7 @@
-let fs = require('fs');
+const fs = require('fs');
+const p = require('path');
 
-let defaultSettings = {
+const defaultSettings = {
   title: 'My project',
   authors: ['Your demoscene handle'],
   description: 'This is my project',
@@ -15,13 +16,13 @@ let defaultSettings = {
 
 function init(projectPath) {
   fs.writeFileSync(
-    projectPath + '/nin.json',
+    p.join(projectPath, 'nin.json'),
     new Buffer(JSON.stringify(defaultSettings, null, '  '))
   );
 }
 
 function load(projectPath) {
-  let rawProjectSettings = fs.readFileSync(projectPath + '/nin.json', 'utf8');
+  let rawProjectSettings = fs.readFileSync(p.join(projectPath, 'nin.json'), 'utf8');
   let projectSettings = JSON.parse(rawProjectSettings);
   return traverse(projectSettings, defaultSettings);
 }
@@ -29,7 +30,7 @@ function load(projectPath) {
 function write(projectPath, parsedProjectSettings) {
   let projectSettingsFile = 'var PROJECT = ' + JSON.stringify(parsedProjectSettings) + ';';
   fs.writeFileSync(
-    projectPath + '/gen/projectSettings.js',
+    p.join(projectPath, 'gen/projectSettings.js'),
     new Buffer(projectSettingsFile)
   );
 }


### PR DESCRIPTION
Modelled after rust's cargo, nin init now takes a required directory
argument, avoiding accidentally initializing nin projects in your
current directory (as many zip-users may be familiar with).

Additionally, nin projects now come with git initialized as well as a
bundled .gitignore tailored for our project format.
This will reduce onboarding friction for new users, as well as
profilerating the spread of git and allowing for easier sharing on
github.