### PR TITLE
Potentially fix race-condition regression with layer generation

### DIFF
--- a/nin/frontend/app/scripts/controllers/main.js
+++ b/nin/frontend/app/scripts/controllers/main.js
@@ -206,17 +206,17 @@ class MainCtrl {
           let graph = JSON.parse(event.content);
 
           for (let nodeInfo of graph) {
-            let node = demo.nm.createNode(nodeInfo);
-
             try {
+              let node = demo.nm.createNode(nodeInfo);
               demo.nm.insertOrReplaceNode(node);
             } catch (e) {
               // This hack only works due to not-yet received
               // nodes created through generate not having
               // any connections / friends.
               $timeout(function () {
+                let node = demo.nm.createNode(nodeInfo);
                 demo.nm.insertOrReplaceNode(node);
-              }, 100);
+              }, 200);
             }
           }
 


### PR DESCRIPTION
Layers -> Generate node in the frontend seems to crash while it didn't
before. If i remember correctly, this is one of the reasons createNode
was inside the try-catch to begin with, and is therefore moved back.