### PR TITLE
Show help message for invalid commands

### DIFF
--- a/nin/backend/nin
+++ b/nin/backend/nin
@@ -64,8 +64,8 @@ program
     generate.generate(projectRoot, resource, name);
   });
 
-program.parse(process.argv);
+const result = program.parse(process.argv);
 
-if(!process.argv.slice(2).length) {
+if(typeof result.args[0] != 'object') {
   program.outputHelp();
 }


### PR DESCRIPTION
Before, the CLI would just silently exit if you tried running it with an
invalid command, e.g. `nin yolo`. Now, the CLI prints the default help
message instead.

before:
![image](https://cloud.githubusercontent.com/assets/578029/21488005/c468c246-cbd9-11e6-949b-3562ee9a6d95.png)

after:
![image](https://cloud.githubusercontent.com/assets/578029/21488002/b89b7da0-cbd9-11e6-9cf6-0031ed16315c.png)
