### PR TITLE
Remove dead code nin command

### DIFF
--- a/nin/backend/nin
+++ b/nin/backend/nin
@@ -42,14 +42,6 @@ program
   });
 
 program
-  .command('headless')
-  .description('Run the backend project headlessly')
-  .action(function() {
-    var shouldRunHeadlessly = true;
-    serve.serve(utils.findProjectRootOrExit(process.cwd()), shouldRunHeadlessly);
-  });
-
-program
   .command('render')
   .description('Render recorded pngs to a video file')
   .action(function(project) {

--- a/nin/backend/serve.js
+++ b/nin/backend/serve.js
@@ -12,7 +12,7 @@ let watch = require('./watch');
 const os = require('os');
 const ini = require('ini');
 
-const serve = function(projectPath, shouldRunHeadlessly) {
+const serve = function(projectPath) {
 
   const genPath = p.join(projectPath, 'gen');
   mkdirp.sync(genPath);
@@ -35,25 +35,23 @@ const serve = function(projectPath, shouldRunHeadlessly) {
     /* eslint-disable */
     projectSettings.generate(projectPath);
 
-    if(!shouldRunHeadlessly) {
-      var frontend = express();
-      frontend.use(express.static(p.join(__dirname, '../frontend/dist')));
-      frontend.get('/.ninrc', (req, res) => {
-        let content = {};
-        const ninrcpath = p.join(os.homedir(), '.ninrc');
-        if (fs.existsSync(ninrcpath)) {
-          try {
-            const rawContent = fs.readFileSync(ninrcpath, 'utf-8');
-            content = ini.parse(rawContent);
-          } catch (e) {
-            console.error('Error while reading .ninrc: ' + e);
-          }
+    var frontend = express();
+    frontend.use(express.static(p.join(__dirname, '../frontend/dist')));
+    frontend.get('/.ninrc', (req, res) => {
+      let content = {};
+      const ninrcpath = p.join(os.homedir(), '.ninrc');
+      if (fs.existsSync(ninrcpath)) {
+        try {
+          const rawContent = fs.readFileSync(ninrcpath, 'utf-8');
+          content = ini.parse(rawContent);
+        } catch (e) {
+          console.error('Error while reading .ninrc: ' + e);
         }
+      }
 
-        res.send(JSON.stringify(content));
-      });
-      frontend.listen(8000);
-    }
+      res.send(JSON.stringify(content));
+    });
+    frontend.listen(8000);
 
     var eventFromPath = function(data) {
       var path = data.path;
@@ -138,11 +136,7 @@ const serve = function(projectPath, shouldRunHeadlessly) {
     mkdirp.sync(projectPath + '/bin/render/');
     files.listen(9000);
 
-    if(shouldRunHeadlessly) {
-      console.log('Running nin headlessly');
-    } else {
-      console.log(chalk.yellow('Serving nin on http://localhost:8000'));
-    }
+    console.log(chalk.yellow('Serving nin on http://localhost:8000'));
   });
 /* eslint-enable*/
 };


### PR DESCRIPTION
Headlessly was ran when the frontend was gulp-based,
and you wanted to dev on it.

Now that everything's webpack, the command's no longer needded.