### PR TITLE
Fix bug in cli help display

### DIFF
--- a/nin/backend/nin
+++ b/nin/backend/nin
@@ -58,6 +58,6 @@ program
 
 const result = program.parse(process.argv);
 
-if(typeof result.args[0] != 'object') {
+if(typeof result.args[result.args.length - 1] != 'object') {
   program.outputHelp();
 }


### PR DESCRIPTION
Previously, generic help text would be displayed when running a command
with optional arguments. Now, the help text is correctly only displayed
when nin is run with no commands at all, or when passed -h or --help.