### PR TITLE
Stay at end of camerapath instead of skip to start

### DIFF
--- a/nin/dasBoot/PathController.js
+++ b/nin/dasBoot/PathController.js
@@ -144,7 +144,7 @@ PathController.prototype.get3Dpoint = function(frame) {
     return current.point;
   } else if (current.type == 'circle') {
     if (frame > current.endFrame) {
-      t = 0;
+      t = 1;
     }
     t += current.offset;
     t *= current.length;


### PR DESCRIPTION
For circle animations, clamp internal time value to the end instead of
jumping back to the start.