### PR TITLE
Swap derivative j k shortcuts

### DIFF
--- a/nin/frontend/app/scripts/directives/menubar.js
+++ b/nin/frontend/app/scripts/directives/menubar.js
@@ -46,13 +46,13 @@ function menubar($window, commands, ninrc) {
         {
           name: 'Rewind one frame',
           action: 'rewindOneFrame',
-          defaultKeybind: 'shift-k',
+          defaultKeybind: 'shift-j',
           invoke: () => commands.jog(-1)
         },
         {
           name: 'Forward one frame',
           action: 'forwardOneFrame',
-          defaultKeybind: 'shift-j',
+          defaultKeybind: 'shift-k',
           invoke: () => commands.jog(1)
         },
         {


### PR DESCRIPTION
We swapped the j and k shortcuts some time ago, but we forgot to also
swap shift-j and shift-k. Now, these are swapped.