### PR TITLE
Rebind fullscreen to enter from f

### DIFF
--- a/nin/frontend/app/scripts/directives/menubar.js
+++ b/nin/frontend/app/scripts/directives/menubar.js
@@ -121,7 +121,7 @@ function menubar($window, commands, ninrc) {
         {
           name: 'Toggle fullscreen',
           action: 'toggleFullscreen',
-          defaultKeybind: 'f',
+          defaultKeybind: 'enter',
           invoke: () => commands.toggleFullscreen()
         },
         {


### PR DESCRIPTION
'f' was colliding with the flyaround controls up / down elevation buttons (bound to r and f).
Backwards compatibility can be attained by creating a .ninrc in your
root folder with the following contents:

```
[keybinds]
toggleFullscreen=f
```