### PR TITLE
Don't crash if git commands fail in nin

### DIFF
--- a/nin/backend/utils.js
+++ b/nin/backend/utils.js
@@ -14,11 +14,17 @@ function getProjectMetadata(projectPath) {
 }
 
 function getNinMetadata() {
+  let sha1, origin;
+  try {
+    sha1 = execSync(`cd ${__dirname} && git rev-parse HEAD`);
+    origin = execSync(`cd ${__dirname} && git config --get remote.origin.url`);
+  } catch (e) {
+  }
   return {
     name: ninPackageJson.name,
     version: ninPackageJson.version,
-    sha1: execSync(`cd ${__dirname} && git rev-parse HEAD`),
-    origin: execSync(`cd ${__dirname} && git config --get remote.origin.url`),
+    sha1,
+    origin,
   };
 }
 


### PR DESCRIPTION
When nin is installed from npm, git is not available. We just let the
git commands fail silently then.

This fixes #344 