### PR TITLE
Switch yarn to npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ all:
 
 .PHONY: publish
 publish: all
-	yarn version major
-	yarn publish
+	npm version major
+	npm publish


### PR DESCRIPTION
Turns out yarn's publish command isn't equivalent to npm's and npm's is nicer for our use-case