### PR TITLE
Add item previews

### DIFF
--- a/nin/frontend/app/scripts/directives/editor/GraphEditor.js
+++ b/nin/frontend/app/scripts/directives/editor/GraphEditor.js
@@ -33,6 +33,24 @@ class GraphEditor extends React.Component {
     this.lastDragEventTime = performance.now();
     this.pinchZoomDistance = 0;
     this.isMouseDragging = false;
+    this.inspectedItem = null;
+  }
+
+  inspect(item) {
+    if(this.inspectedItem) {
+      this.inspectedItem.__isInspected = false;
+      const value = this.inspectedItem.getValue();
+      if(value == demo.renderer.overrideToScreenTexture) {
+        demo.renderer.overrideToScreenTexture = null;
+      }
+      if(item == this.inspectedItem) {
+        item = null;
+      }
+    }
+    this.inspectedItem = item;
+    if(item) {
+      item.__isInspected = true;
+    }
   }
 
   generateDepths() {
@@ -304,6 +322,13 @@ class GraphEditor extends React.Component {
                    this.props.nodes[toNodeId].active),
           key: `${fromNodeId}.${fromIOId}|${toNodeId}.${toIOId}`
         });
+      }
+    }
+
+    if(this.inspectedItem) {
+      const value = this.inspectedItem.getValue();
+      if(value instanceof THREE.Texture) {
+        demo.renderer.overrideToScreenTexture = value;
       }
     }
 

--- a/nin/frontend/app/scripts/directives/editor/GraphEditorInputOutput.js
+++ b/nin/frontend/app/scripts/directives/editor/GraphEditorInputOutput.js
@@ -72,11 +72,14 @@ class GraphEditorInputOutput extends React.Component {
       e('circle', {
         cx: 0,
         cy: 0,
-        r: 5,
+        r: this.props.item.__isInspected ? 10 : 5,
         fill: isConnected ? 'white' : 'transparent',
-        stroke: 'white',
-        strokeWidth: 2,
-        onClick: event => {this.props.editor.startOrCompleteConnection(this.props.item);},
+        stroke: this.props.item.__isInspected ? 'orange' : 'white',
+        strokeWidth: this.props.item.__isInspected ? 5 : 2,
+        style: {
+          cursor: 'pointer',
+        },
+        onClick: event => {this.props.editor.inspect(this.props.item);},
       }),
       this.props.scale >= 1.5 ? e('text', {
         x: 0,


### PR DESCRIPTION
Click a node input or output to inspect it. If the item holds a texture
value, it will be rendered to the screen for inspection! In the future,
we can add inspection for other types as well, and for other items like
nodes.

![](https://i.gyazo.com/5dc7c6145d30f93e4995328b0a50f8d0.gif)

![](https://i.gyazo.com/2a4de397432d89d633b0fb8786b63ff9.gif)