### PR TITLE
Don't fallback on falsy values in PathController

### DIFF
--- a/nin/dasBoot/PathController.js
+++ b/nin/dasBoot/PathController.js
@@ -91,8 +91,11 @@ PathController.prototype.parseKeyframes = function(keyframes) {
       easing: keyframes[i].easing
     };
 
-    var raw_points =
-      keyframes[i].value || keyframes[i].point || keyframes[i].points;
+    var raw_points = keyframes[i].hasOwnProperty('value')
+      ? keyframes[i].value
+      : keyframes[i].hasOwnProperty('point')
+        ? keyframes[i].point
+        : keyframes[i].points;
 
     if (raw_points) {
       if (typeof raw_points === 'number') {


### PR DESCRIPTION
PathController allows multiple property names to be used for the same
value, but if the value was set to 0, the fallback chain would collapse
because 0 is a falsy value.