### PR TITLE
Fix BEATBEAN ordering when compiling

### DIFF
--- a/nin/backend/compile.js
+++ b/nin/backend/compile.js
@@ -151,8 +151,6 @@ const compile = function(projectPath, options) {
         'GU=1;' + /* hack to make sure GU exisits from the get-go */
         'BEAN=0;' +
         'BEAT=false;' +
-        'FRAME_FOR_BEAN=function placeholder(){};' +
-        'BEAN_FOR_FRAME=function placeholder(){};' +
         data +
         'var graph = JSON.parse(atob(FILES["res/graph.json"]));' +
         'demo=bootstrap({graph:graph, onprogress: ONPROGRESS, oncomplete: ONCOMPLETE});' +

--- a/nin/backend/compress.js
+++ b/nin/backend/compress.js
@@ -75,8 +75,6 @@ function compress(projectPath, payload, htmlPreamble, metadata, callback) {
           'GU=1;' + /* hack to make sure GU exisits from the get-go */
           'BEAN=0;' + 
           'BEAT=false;' +
-          'FRAME_FOR_BEAN=function placeholder(){};' +
-          'BEAN_FOR_FRAME=function placeholder(){};' +
           '(1,eval)(s);' +
           'var graph = JSON.parse(atob(FILES["res/graph.json"]));' +
           'demo=bootstrap({graph:graph, onprogress: ONPROGRESS, oncomplete: ONCOMPLETE});' +

--- a/nin/dasBoot/bootstrap.js
+++ b/nin/dasBoot/bootstrap.js
@@ -13,6 +13,8 @@ window['bootstrap'] = function(options) {
 
   Loader.setRootPath(options.rootPath || '');
 
+  initBeatBean();
+
   demo.nm = new NodeManager(demo);
 
   demo.setContainer = function(c) {
@@ -78,8 +80,6 @@ window['bootstrap'] = function(options) {
   demo.resize();
 
   demo.music = loadMusic();
-
-  initBeatBean();
 
   demo.looper = createLoop({
     render: demo.render,


### PR DESCRIPTION
This makes BEATBEAN properly available in Node constructors in compiled
demos.