### PR TITLE
Fix system specific path breaking Windows reloading on save.

### DIFF
--- a/nin/backend/watch.js
+++ b/nin/backend/watch.js
@@ -44,7 +44,7 @@ function watch(projectPath, cb) {
                   chalk.magenta(path));
     }
 
-    cb(event, {path: path});
+    cb(event, {path: path.replace(/\\/g,"/")});
 
     // Maintain list of files that the frontend will need to load initially
     if (event === 'add') {


### PR DESCRIPTION
This will ensure that the path of reloading files are not Windows formated.