### PR TITLE
Update ShaderNode generation to use graph.json

### DIFF
--- a/nin/backend/generate/TemplateShaderNode.js
+++ b/nin/backend/generate/TemplateShaderNode.js
@@ -1,7 +1,6 @@
 (function(global) {
   class TemplateShaderNode extends NIN.ShaderNode {
     constructor(id, options) {
-      options.shader = SHADERS.TemplateShader;
       super(id, options);
     }
 

--- a/nin/backend/generate/generate.js
+++ b/nin/backend/generate/generate.js
@@ -57,8 +57,7 @@ const generate = function(projectRoot, type, name, options) {
         const shaderFilename = name + 'Node';
         generateLayer(shaderFilename,
           'TemplateShaderNode.js',
-          [[/TemplateShaderNode/g, shaderFilename],
-           [/TemplateShader/g, name]],
+          [[/TemplateShaderNode/g, shaderFilename]],
           projectRoot);
 
         generateShader(name, projectRoot);
@@ -67,7 +66,9 @@ const generate = function(projectRoot, type, name, options) {
           graph.push({
             id: name,
             type: shaderFilename,
-            options: {},
+            options: {
+              shader: name,
+            },
           });
         }, err => {
           if (err) {


### PR DESCRIPTION
This means live-reload for shaders will be enabled by default.

This fixes #373.