### PR TITLE
Fix printing of error message for generate command

### DIFF
--- a/nin/backend/generate/generate.js
+++ b/nin/backend/generate/generate.js
@@ -80,7 +80,7 @@ const generate = function(projectRoot, type, name, options) {
       break;
 
     default:
-      process.stderr.write('Attempted to generate resource without generator:', type, '\n');
+      process.stderr.write(`Attempted to generate resource without generator: ${type}\n`);
   }
 };
 


### PR DESCRIPTION
process.stderr.write only accepts one argument