### PR TITLE
Add option for only closure compiling whitespace

### DIFF
--- a/nin/backend/compile.js
+++ b/nin/backend/compile.js
@@ -179,6 +179,7 @@ const compile = function(projectPath, options) {
               path
             }));
           const out = closureCompiler.compile({
+            compilationLevel: options.whitespaceOnly ? 'WHITESPACE_ONLY' : 'SIMPLE',
             jsCode: jsCode
           });
           if(out.errors.length) {

--- a/nin/backend/nin
+++ b/nin/backend/nin
@@ -26,9 +26,8 @@ program
   .command('compile')
   .description('Compile the nin project')
   .option('--no-optimize-png-assets', 'Do not use optipng to optimize assets')
-  .action(options => compile.compile(utils.findProjectRootOrExit(process.cwd()), {
-    optimizePngAssets: options.optimizePngAssets
-  }));
+  .option('--whitespace-only', 'Only remove whitespace with Google Closure Compiler (faster)')
+  .action(options => compile.compile(utils.findProjectRootOrExit(process.cwd()), options));
 
 program
   .command('run [port]')


### PR DESCRIPTION
On my machine this reduces compile time from 2 minutes to 1 minute.
Meanwhile, the filesize increased (in the one example I tested with) from
5.2 MB to 5.3 MB.

This will be nice for incremental testing of compiles etc.