### PR TITLE
Add better font support

### DIFF
--- a/nin/backend/fontgen.js
+++ b/nin/backend/fontgen.js
@@ -1,0 +1,43 @@
+const fs = require('fs-promise');
+const glob = require('glob');
+const path = require('path');
+
+
+async function fontGen(pathPrefix) {
+
+  let resolver;
+  let promise = new Promise(resolve => {
+    resolver = resolve; 
+  });
+
+  glob(path.join(pathPrefix, 'res/**/*.otf'), {}, async (error, filenames) => {
+    let fonts = {};
+    for(const filename of filenames) {
+      const file = fs.readFileSync(filename);
+      const name = path.basename(filename, '.otf');
+      fonts[name] = file.toString('base64');
+    }
+
+    const fontjs = `(() => {
+      const fonts = ${JSON.stringify(fonts)};
+      for(const name in fonts) {
+        const id = name + '-font';
+        const font = fonts[name];
+        const s = document.createElement('style');
+        s.setAttribute('id', id);
+        s.innerHTML = [
+          '@font-face {',
+          'font-family: "' + name + '";',
+          'src: url(data:application/x-font-opentype;charset=utf-8;base64,' + font + ') format("opentype");',
+          '}'
+        ].join('\\n');
+        document.body.appendChild(s);
+      }
+    })();`;
+    await fs.writeFile(path.join(pathPrefix, 'gen', 'fonts.js'), fontjs);
+    resolver();
+  });
+  return promise;
+}
+
+module.exports = fontGen;

--- a/nin/backend/serve.js
+++ b/nin/backend/serve.js
@@ -9,13 +9,17 @@ const socket = require('./socket');
 const utils = require('./utils');
 const watch = require('./watch');
 const dasbootGen = require('./dasbootgen');
+const fontGen = require('./fontgen');
 
 const serve = async function(
     projectPath,
     frontendPort=8000) {
   const genPath = p.join(projectPath, 'gen');
   await fs.emptyDir(genPath);
-  await dasbootGen(projectPath);
+  await Promise.all([
+    fontGen(projectPath),
+    dasbootGen(projectPath),
+  ]);
   projectSettings.generate(projectPath);
 
   const frontend = express();

--- a/nin/frontend/app/index.html
+++ b/nin/frontend/app/index.html
@@ -10,6 +10,7 @@
 
     <script src="/project/gen/dasBoot.js"></script>
     <script src="/project/gen/shaders.js"></script>
+    <script src="/project/gen/fonts.js"></script>
     <script src="/project/gen/projectSettings.js"></script>
 
     <script src="app.bundle.js"></script>


### PR DESCRIPTION
Fonts can now be added to the res/ folder, and they will be
automagically be made available as a `@font-face` with the same name as
the font file (without suffix). As an example: `res/myfont.otf` will be
available for a 2D canvas as `ctx.font = '10pt myfont';`. Only .otf is
supported for now.

Before this commit, the typical way of adding fonts was to manually
convert otf to base64 offline, load that with Loader.loadAjax, and take
care to create a style tag with the font definition somewhere in the
demo.

Some font loaded in some demo:
![image](https://cloud.githubusercontent.com/assets/578029/25304946/0128c250-2772-11e7-9e69-71e0d208f28b.png)

Fonts being skipped when assimilating res:
![image](https://cloud.githubusercontent.com/assets/578029/25304949/14b56008-2772-11e7-919f-8a09bd7999a4.png)
