### PR TITLE
Add default SceneSwitcherNode to ease new project startup

### DIFF
--- a/nin/backend/blank-project/res/graph.json
+++ b/nin/backend/blank-project/res/graph.json
@@ -3,7 +3,15 @@
     "id": "root",
     "type": "NIN.RootNode",
     "connected": {
-        "screen": "SpinningCube.render"
+      "screen": "sceneSwitcherNode.render"
+    }
+  },
+  {
+    "id": "sceneSwitcherNode",
+    "type": "SceneSwitcherNode",
+    "connected": {
+      "A": "SpinningCube.render",
+      "B": "SpinningCube.render"
     }
   }
 ]

--- a/nin/backend/blank-project/src/SceneSwitcherNode.js
+++ b/nin/backend/blank-project/src/SceneSwitcherNode.js
@@ -1,0 +1,32 @@
+(function(global) {
+  class SceneSwitcherNode extends NIN.Node {
+    constructor(id) {
+      super(id, {
+        inputs: {
+          A: new NIN.TextureInput(),
+          B: new NIN.TextureInput(),
+        },
+        outputs: {
+          render: new NIN.TextureOutput(),
+        }
+      });
+    }
+
+    update() {
+      this.inputs.A.enabled = false;
+      this.inputs.B.enabled = false;
+
+      let selectedScene;
+      if (BEAN < 48 * 4) {
+        selectedScene = this.inputs.A;
+      } else {
+        selectedScene = this.inputs.B;
+      }
+
+      selectedScene.enabled = true;
+      this.outputs.render.setValue(selectedScene.getValue());
+    }
+  }
+
+  global.SceneSwitcherNode = SceneSwitcherNode;
+})(this);


### PR DESCRIPTION
Based on our experiences from revision, i've added a minimal SceneSwitcherNode to help new projects get started.
Additionally, it counts as documentation, giving an example on how to switch between multiple nodes based on the current BEAN.