### PR TITLE
Stop demo properly when it reaches end

### DIFF
--- a/nin/dasBoot/bootstrap.js
+++ b/nin/dasBoot/bootstrap.js
@@ -96,7 +96,7 @@ window['bootstrap'] = function(options) {
     var time = (frame / 60) * 1000;
     if (time > demo.music.getDuration() * 1000) {
       time = demo.music.getDuration() * 1000;
-      frame = (time / 1000) * 60;
+      frame = (time / 1000) * 60 | 0;
     }
     else if (frame < 0) {
       frame = 0;

--- a/nin/frontend/app/scripts/utils/render.js
+++ b/nin/frontend/app/scripts/utils/render.js
@@ -1,7 +1,6 @@
 const demo = require('../demo');
 const commands = require('../commands');
 
-let currentFrame;
 let currentlyRendering = false;
 let currentTimeout;
 
@@ -19,8 +18,13 @@ commands.on('stopRendering', () => {
 
 function render(i) {
   i = i || 0;
-  currentFrame = i;
   demo.jumpToFrame(i);
+  const currentFrame = demo.getCurrentFrame();
+  if (currentFrame < i) {
+    currentlyRendering = false;
+    return;
+  }
+
   const image = demo.renderer.domElement.toDataURL('image/png');
 
   fetch('http://localhost:9000/', {
@@ -31,7 +35,7 @@ function render(i) {
     body: JSON.stringify({
       type: 'render-frame',
       image: image,
-      frame: i
+      frame: currentFrame,
     })
   });
 

--- a/nin/frontend/app/styles/common.less
+++ b/nin/frontend/app/styles/common.less
@@ -76,6 +76,7 @@ main-window, main-window > div {
   height: 50px;
   position: absolute;
   bottom: 0;
+  overflow: hidden;
 }
 
 body.fullscreen .bottom {


### PR DESCRIPTION
This fixes two issues:

1. When the demo reaches the end during playback, it sometimes ended on a decimal-numbered frame. Frame numbers will with this fix always be integers.
2. When rendering a demo to images, the rendering never stopped, even after the end of the song. This is now resolved.