### PR TITLE
Switch font loader to use woff2 instead of otf

### DIFF
--- a/nin/backend/compile.js
+++ b/nin/backend/compile.js
@@ -47,7 +47,7 @@ function res(projectPath, options, callback) {
 
     const filename = root + stat.name;
     const file = await fs.readFile(filename);
-    if(p.extname(filename) == '.otf') {
+    if(p.extname(filename) == '.woff2') {
       process.stdout.write('- Skipping ' + chalk.grey(root.slice(projectPath.length + 1)) + chalk.magenta(stat.name) + chalk.grey(', (it is a font)'));
       renderOK();
       next();

--- a/nin/backend/fontgen.js
+++ b/nin/backend/fontgen.js
@@ -7,14 +7,14 @@ async function fontGen(pathPrefix) {
 
   let resolver;
   let promise = new Promise(resolve => {
-    resolver = resolve; 
+    resolver = resolve;
   });
 
-  glob(path.join(pathPrefix, 'res/**/*.otf'), {}, async (error, filenames) => {
+  glob(path.join(pathPrefix, 'res/**/*.woff2'), {}, async (error, filenames) => {
     let fonts = {};
     for(const filename of filenames) {
       const file = fs.readFileSync(filename);
-      const name = path.basename(filename, '.otf');
+      const name = path.basename(filename, '.woff2');
       fonts[name] = file.toString('base64');
     }
 
@@ -28,7 +28,7 @@ async function fontGen(pathPrefix) {
         s.innerHTML = [
           '@font-face {',
           'font-family: "' + name + '";',
-          'src: url(data:application/x-font-opentype;charset=utf-8;base64,' + font + ') format("opentype");',
+          'src: url(data:application/x-font-woff2;charset=utf-8;base64,' + font + ') format("woff2");',
           '}'
         ].join('\\n');
         document.body.appendChild(s);


### PR DESCRIPTION
otf files have no compression while woff and woff2 provide much smaller
font files. The one example I tested on (the font vcr from `re`) was
half the filesize of the corresponding otf file, and reduced the size of
the .png-compiled demo by almost 2 kB (that's almost half a 4k demo!).

Woff2 also has basically as good browser support as otf, only lacking
internet explorer (but edge works!), and Safari for those not running
the latest macOS/iOS. Before we release another prod, I don't think that
will be an issue.