### PR TITLE
Fix loading of muted state from local storage

### DIFF
--- a/nin/frontend/app/scripts/components/main.js
+++ b/nin/frontend/app/scripts/components/main.js
@@ -27,13 +27,10 @@ class Main extends React.Component {
       fullscreen: false,
       showFramingOverlay: false,
       mute: localStorage.getItem('nin-mute') ? true : false,
-      volume: 1,
       globalJSErrors: {},
     };
 
-    if (localStorage.hasOwnProperty('nin-volume')) {
-      this.state.volume = +localStorage.getItem('nin-volume');
-    }
+    demo.music.setVolume(1 - this.state.mute);
 
     commands.on('selectTheme', theme => {
       var foundTheme = false;
@@ -63,14 +60,14 @@ class Main extends React.Component {
     });
 
     commands.on('toggleMusic', () => {
-      this.setState({mute: !this.state.mute});
       if (!this.state.mute) {
         localStorage.setItem('nin-mute', 1);
         demo.music.setVolume(0);
       } else {
         localStorage.removeItem('nin-mute');
-        demo.music.setVolume(this.state.volume);
+        demo.music.setVolume(1);
       }
+      this.setState({mute: !this.state.mute});
     });
 
     socketController.socket.onopen = function() {


### PR DESCRIPTION
Turns out we have kept around a volume parameter for a while without
ever having a possibility to set the volume to anything other than 1 or
0. I take this as a hint that this functionality is not needed and
simplified the muting a bit in the process.