### PR TITLE
Reload flycontrols when a node is updated

### DIFF
--- a/nin/frontend/app/scripts/components/editor/FlyaroundController.js
+++ b/nin/frontend/app/scripts/components/editor/FlyaroundController.js
@@ -1,8 +1,6 @@
 class FlyaroundController {
   constructor(node) {
-    this.scene = node.scene;
-    this.camera = node.camera;
-    this.cameraController = node.cameraController;
+    this.updateNodeInstance(node);
     this.clock = new THREE.Clock();
 
     this.camera.isOverriddenByFlyControls = false;
@@ -12,6 +10,12 @@ class FlyaroundController {
     document.body.appendChild(this.outputContainer);
 
     this.toggleFlyAroundMode();
+  }
+
+  updateNodeInstance(node) {
+    this.scene = node.scene;
+    this.camera = node.camera;
+    this.cameraController = node.cameraController;
   }
 
   mouseclick(e) {

--- a/nin/frontend/app/scripts/components/editor/GraphEditorNode.js
+++ b/nin/frontend/app/scripts/components/editor/GraphEditorNode.js
@@ -52,6 +52,21 @@ class GraphEditorNode extends React.Component {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.node !== this.props.node) {
+      if (this.flyaroundController) {
+        this.flyaroundController.updateNodeInstance(nextProps.node);
+        if (this.props.node.camera.isOverriddenByFlyControls) {
+          const cameraCopy = this.props.node.camera.clone();
+          setTimeout(() => {
+            nextProps.node.camera.copy(cameraCopy);
+          });
+          this.flyaroundController.toggleFlyAroundMode();
+        }
+      }
+    }
+  }
+
   render() {
     const node = this.props.node;
     const width = 200;


### PR DESCRIPTION
This fixes an issue where flyaround controls stops working when a node
is reloaded.