### PR TITLE
Maintain inspection state over node reloads

### DIFF
--- a/nin/frontend/app/scripts/components/editor/GraphEditor.js
+++ b/nin/frontend/app/scripts/components/editor/GraphEditor.js
@@ -59,7 +59,7 @@ class GraphEditor extends React.Component {
   inspect(item) {
     if(this.inspectedItem) {
       this.inspectedItem.__isInspected = false;
-      const value = this.inspectedItem.getValue();
+      const value = this.inspectedItem.props.item.getValue();
       if(value == demo.renderer.overrideToScreenTexture) {
         demo.renderer.overrideToScreenTexture = null;
       }
@@ -353,7 +353,7 @@ class GraphEditor extends React.Component {
     }
 
     if(this.inspectedItem) {
-      const value = this.inspectedItem.getValue();
+      const value = this.inspectedItem.props.item.getValue();
       if(value instanceof THREE.Texture) {
         demo.renderer.overrideToScreenTexture = value;
       }

--- a/nin/frontend/app/scripts/components/editor/GraphEditorInputOutput.js
+++ b/nin/frontend/app/scripts/components/editor/GraphEditorInputOutput.js
@@ -29,14 +29,14 @@ class GraphEditorInputOutput extends React.Component {
       e('circle', {
         cx: 0,
         cy: 0,
-        r: this.props.item.__isInspected ? 10 : 5,
+        r: this.__isInspected ? 10 : 5,
         fill: isConnected ? 'white' : 'transparent',
-        stroke: this.props.item.__isInspected ? 'orange' : 'white',
-        strokeWidth: this.props.item.__isInspected ? 5 : 2,
+        stroke: this.__isInspected ? 'orange' : 'white',
+        strokeWidth: this.__isInspected ? 5 : 2,
         style: {
           cursor: 'pointer',
         },
-        onClick: event => {this.props.editor.inspect(this.props.item);},
+        onClick: event => {this.props.editor.inspect(this);},
       }),
       this.props.scale >= 1.5 ? e('text', {
         x: 0,


### PR DESCRIPTION
Store the inspection state on the react component instead of on the node
instance to make it persist over the reload of node instances.