### PR TITLE
Specify displayed width of waveform canvas

### DIFF
--- a/nin/frontend/app/scripts/components/waveform.js
+++ b/nin/frontend/app/scripts/components/waveform.js
@@ -127,6 +127,7 @@ class WaveformWrapper extends React.Component {
           style={{
             position: 'absolute',
             top: '0px',
+            width: 'calc(100% - 50px)',
           }}
           >
         </canvas>


### PR DESCRIPTION
Without this, the canvas would not be correctly sized on retina screens.