### PR TITLE
Replace zlib deflate with zopfli (free filesize reduction!)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
      - g++-4.8
+before_install:
+  - export CXX=g++
+  - export CC=gcc
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX=g++-4.8; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,9 @@ install:
 script:
   - cd nin/backend && ../../node_modules/.bin/eslint .
   - cd ../frontend && make lint
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+     - g++-4.8

--- a/nin/backend/compress.js
+++ b/nin/backend/compress.js
@@ -1,5 +1,5 @@
 let crc = require('crc').crc32;
-let zlib = require('zlib');
+let zopfli = require('node-zopfli');
 
 
 function positiveNumberToBytes(number, bytes) {
@@ -105,7 +105,7 @@ async function compress(projectPath, payload, htmlPreamble, metadata) {
   }));
 
   return new Promise(resolve => {
-    zlib.deflate(scanlinesBuffer, function(err, buffer){
+    zopfli.zlib(scanlinesBuffer, {}, function(err, buffer){
       let IDATData = Buffer.concat([
         buffer,
         positiveNumberToBytes(crc(scanlinesBuffer), 4)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "glsl-parser": "^2.0.0",
     "google-closure-compiler-js": "^20170409.0.0",
     "ini": "1.3.4",
+    "node-zopfli": "2.0.2",
     "optipng": "1.0.0",
     "sockjs": "0.3.16",
     "walk": "2.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,7 +562,7 @@ clone@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/clone/-/clone-0.2.0.tgz#c6126a90ad4f72dbf5acdb243cc37724fe93fc1f"
 
-clone@^1.0.0:
+clone@^1.0.0, clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
 
@@ -592,7 +592,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0, commander@^2.9.0:
+commander@2.9.0, commander@^2.8.1, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -833,6 +833,12 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+defaults@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  dependencies:
+    clone "^1.0.2"
 
 del@^2.0.2:
   version "2.2.2"
@@ -2412,7 +2418,7 @@ mz@^2.6.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.3.0:
+nan@^2.0.0, nan@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.0.tgz#aa8f1e34531d807e9e27755b234b4a6ec0c152a8"
 
@@ -2452,7 +2458,7 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-pre-gyp@^0.6.29:
+node-pre-gyp@^0.6.29, node-pre-gyp@^0.6.4:
   version "0.6.32"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz#fc452b376e7319b3d255f5f34853ef6fd8fe1fd5"
   dependencies:
@@ -2473,6 +2479,15 @@ node-status-codes@^1.0.0:
 node-uuid@^1.4.1:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
+
+node-zopfli@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-zopfli/-/node-zopfli-2.0.2.tgz#a7a473ae92aaea85d4c68d45bbf2c944c46116b8"
+  dependencies:
+    commander "^2.8.1"
+    defaults "^1.0.2"
+    nan "^2.0.0"
+    node-pre-gyp "^0.6.4"
 
 nopt@~3.0.6:
   version "3.0.6"


### PR DESCRIPTION
Zopfli is a zlib-compatible compression algorithm, which means it can be
used as a drop-in replacement inside PNG, while giving generally better
compression.

Testing on ninjadev/re shows a 60kB filesize decrease when using zopfli
instead of zlib.

The node-zopfli package has bindings to a zopfli c-implementation, so hopefully it's not much hassle to install on windows. The documentation suggests it should work fine, though.