### PR TITLE
Re-render current frame after shader or node change

### DIFF
--- a/nin/frontend/app/scripts/components/main.tsx
+++ b/nin/frontend/app/scripts/components/main.tsx
@@ -161,6 +161,7 @@ export default class Main extends React.Component<any, any> {
           }
 
           demo.nm.update(demo.looper.currentFrame);
+          demo.nm.render(demo.renderer);
           Loader.start(function() {}, function() {});
           break;
 
@@ -180,6 +181,7 @@ export default class Main extends React.Component<any, any> {
           }
 
           demo.nm.update(demo.looper.currentFrame);
+          demo.nm.render(demo.renderer);
           Loader.start(function() {}, function() {});
           break;
         }


### PR DESCRIPTION
Recompiling shaders before this fix would result in a white frame if
paused.