### PR TITLE
Make sure nodes always have an output property

### DIFF
--- a/nin/dasBoot/THREENode.js
+++ b/nin/dasBoot/THREENode.js
@@ -1,5 +1,8 @@
 class THREENode extends NIN.Node {
   constructor(id, options) {
+    if(!('outputs' in options)) {
+      options.outputs = {};
+    }
     if(!('render' in options.outputs)) {
       options.outputs.render = new NIN.TextureOutput();
     }


### PR DESCRIPTION
4545fcdc1808618723a4f5cd8a228b5c0b121ab7 broke nodes that did not have
an output property specified at all, and that relied on NIN.Node to
provide the whole output setup for them. This made ninjadev/re stop
working, so here's a fix for that.