### PR TITLE
Remove double node connection in default graph

### DIFF
--- a/nin/backend/blank-project/res/graph.json
+++ b/nin/backend/blank-project/res/graph.json
@@ -10,8 +10,7 @@
     "id": "sceneSwitcherNode",
     "type": "SceneSwitcherNode",
     "connected": {
-      "A": "SpinningCube.render",
-      "B": "SpinningCube.render"
+      "A": "SpinningCube.render"
     }
   }
 ]


### PR DESCRIPTION
This breaks auto-reload in newly generated projects.