### PR TITLE
Add first steps towards an ui-editable graph

### DIFF
--- a/nin/backend/socket.js
+++ b/nin/backend/socket.js
@@ -37,6 +37,20 @@ function socket(projectPath, onConnectionCallback) {
     conn.on('data', function (message) {
       let event = JSON.parse(message);
       switch (event.type) {
+        case 'graph-disconnect':
+          graph.transform(projectPath, g => {
+            const index = g.findIndex(nodeInfo => nodeInfo.id === event.data.toNode);
+            delete g[index].connected[event.data.toInput];
+          });
+          break;
+
+        case 'graph-connect':
+          graph.transform(projectPath, g => {
+            const index = g.findIndex(nodeInfo => nodeInfo.id === event.data.toNode);
+            g[index].connected[event.data.toInput] = event.data.fromNode + '.' + event.data.fromOutput;
+          });
+          break;
+
         case 'set':
           // TODO: Untested, nothing uses this yet
           graph.transform(projectPath, function(g) {

--- a/nin/backend/watch.js
+++ b/nin/backend/watch.js
@@ -5,12 +5,14 @@ const shaderGen = require('./shadergen');
 
 
 function watch(projectPath, cb) {
-  let paths = [];
+  let paths = ['res/graph.json'];
+
+  /* sent only once, must come first */
+  cb('add', {path: 'res/graph.json'});
 
   const watcher = chokidar.watch(
     [ 'src/',
       'lib/',
-      'res/graph.json',
       'res/*.camera.json'],
     {
       ignored: [/[\/\\]\./, /\/shaders\//, /___jb_tmp___/, /___jb_old___/],
@@ -57,6 +59,7 @@ function watch(projectPath, cb) {
       }
     }
   });
+
 
   const shaderWatcher = chokidar.watch('src/shaders/', {
     ignored: /[\/\\]\./,

--- a/nin/frontend/app/scripts/components/editor/Connection.js
+++ b/nin/frontend/app/scripts/components/editor/Connection.js
@@ -8,12 +8,12 @@ class Connection extends React.Component {
     this.state = {
       showDeleteButton: true
     };
-  }
 
-  delete() {
-    this.props.editor.removeConnection(
-      this.props.fromPath,
-      this.props.toPath,);
+    this.delete = () => {
+      this.props.editor.removeConnection(
+        this.props.fromPath,
+        this.props.toPath,);
+    };
   }
 
   render() {
@@ -33,6 +33,24 @@ class Connection extends React.Component {
           pointerEvents="none"
           strokeDasharray={this.props.connection.active ? undefined : '20, 10'}
         />
+
+        <circle
+          className="graph-editor-line-x"
+          cx={midX}
+          cy={midY}
+          r={10 / this.props.scale}
+          onClick={this.delete}
+          style={{
+            cursor: 'pointer',
+          }}
+        >
+          <circle
+            cx={midX}
+            cy={midY}
+            r={3 / this.props.scale}
+            fill="white"
+          />
+      </circle>
       </g>
     );
   }

--- a/nin/frontend/app/scripts/components/editor/GraphEditor.jsx
+++ b/nin/frontend/app/scripts/components/editor/GraphEditor.jsx
@@ -2,6 +2,7 @@ const GraphEditorNode = require('./GraphEditorNode');
 const Connection = require('./Connection');
 const React = require('react');
 
+
 class GraphEditor extends React.Component {
   constructor() {
     super();
@@ -11,6 +12,7 @@ class GraphEditor extends React.Component {
       y: 0,
       connectionStart: null,
       connectionEnd: {},
+      connectionMouseStart: null,
     };
 
     this.scaleAnimationStart = this.state.scale;
@@ -53,6 +55,69 @@ class GraphEditor extends React.Component {
     this.pinchZoomDistance = 0;
     this.isMouseDragging = false;
     this.inspectedItem = null;
+  }
+
+  removeConnection(from, to) {
+    const fromNode = from.split('.')[0];
+    const fromOutput = from.split('.')[1];
+    const toNode = to.split('.')[0];
+    const toInput = to.split('.')[1];
+    for(let i = 0; i < this.props.graph.length; i++) {
+      const nodeInfo = this.props.graph[i];
+      if(nodeInfo.id === toNode) {
+        demo.nm.disconnect(fromNode, fromOutput, toNode, toInput);
+        delete nodeInfo.connected[toInput];
+        this.props.socket.sendEvent('graph-disconnect', {
+          fromNode,
+          fromOutput,
+          toNode,
+          toInput,
+        });
+        break;
+      }
+    }
+  }
+
+  connectClick(event, io) {
+    if(!this.state.connectionStart) {
+      const connectionStart = {
+        x: io.props.node.props.x + io.props.x,
+        y: io.props.node.props.y + io.props.y,
+      };
+      const connectionMouseStart = {
+        x: (event.pageX - (io.props.node.props.x + io.props.x)) / this.state.scale,
+        y: (event.pageY - (io.props.node.props.y + io.props.y)) / this.state.scale,
+      };
+      this.setState({
+        connectionStart,
+        connectionMouseStart,
+        connectionStartIo: io,
+      });
+    } else {
+      const fromNode = this.state.connectionStartIo.props.node.props.id;
+      const fromOutput = this.state.connectionStartIo.props.id;
+      const toNode = io.props.node.props.id;
+      const toInput = io.props.id;
+      demo.nm.connect(fromNode, fromOutput, toNode, toInput);
+      this.props.socket.sendEvent('graph-connect', {
+        fromNode,
+        fromOutput,
+        toNode,
+        toInput,
+      });
+      this.setState({
+        connectionStart: undefined,
+        connectionMouseStart: undefined,
+        connectionStartIo: undefined,
+      });
+      for(let i = 0; i < this.props.graph.length; i++) {
+        const nodeInfo = this.props.graph[i];
+        if(nodeInfo.id === toNode) {
+          nodeInfo.connected[toInput] = fromNode + '.' + fromOutput;
+          break;
+        }
+      }
+    }
   }
 
   inspect(item) {
@@ -302,8 +367,8 @@ class GraphEditor extends React.Component {
         if(this.state.connectionStart) {
           this.setState({
             connectionEnd: {
-              x: event.offsetX - this.state.x,
-              y: event.offsetY - this.state.y,
+              x: event.pageX / this.state.scale - this.state.connectionMouseStart.x,
+              y: event.pageY / this.state.scale - this.state.connectionMouseStart.y,
             }
           });
         }
@@ -345,6 +410,7 @@ class GraphEditor extends React.Component {
       <GraphEditorNode
         nodeInfo={nodeInfo}
         key={nodeInfo.id}
+        id={nodeInfo.id}
         scale={this.state.scale}
         node={this.props.nodes[nodeInfo.id]}
         x={nodeInfo.x}
@@ -385,6 +451,15 @@ class GraphEditor extends React.Component {
         });
       }
     }
+    if(this.state.connectionStart) {
+      connections.push({
+        from: this.state.connectionStart,
+        to: this.state.connectionEnd,
+        active: true,
+        key: 'new-connection',
+      });
+      //console.log(this.state.connectionEnd);
+    }
 
     if(this.inspectedItem) {
       const value = this.inspectedItem.props.item.getValue();
@@ -397,7 +472,7 @@ class GraphEditor extends React.Component {
       <Connection
         connection={connection}
         fromPath={connection.key.split('|')[0]}
-        fromPath={connection.key.split('|')[1]}
+        toPath={connection.key.split('|')[1]}
         editor={this}
         scale={this.state.scale}
         key={connection.key}

--- a/nin/frontend/app/scripts/components/editor/GraphEditorInputOutput.js
+++ b/nin/frontend/app/scripts/components/editor/GraphEditorInputOutput.js
@@ -36,7 +36,10 @@ class GraphEditorInputOutput extends React.Component {
         style: {
           cursor: 'pointer',
         },
-        onClick: event => {this.props.editor.inspect(this);},
+        onClick: event => {
+          this.props.editor.connectClick(event, this);
+          //this.props.editor.inspect(this);
+        },
       }),
       this.props.scale >= 1.5 ? e('text', {
         x: 0,

--- a/nin/frontend/app/scripts/components/editor/GraphEditorNode.js
+++ b/nin/frontend/app/scripts/components/editor/GraphEditorNode.js
@@ -99,6 +99,7 @@ class GraphEditorNode extends React.Component {
         scale: this.props.scale,
         demo: this.props.demo,
         editor: this.props.editor,
+        node: this,
       })),
       Object.keys(node.outputs).map((key, i) => e(GraphEditorInputOutput, {
         item: node.outputs[key],
@@ -109,6 +110,7 @@ class GraphEditorNode extends React.Component {
         scale: this.props.scale,
         demo: this.props.demo,
         editor: this.props.editor,
+        node: this,
       })),
       e('text', {
         className: 'name',

--- a/nin/frontend/app/scripts/components/main.tsx
+++ b/nin/frontend/app/scripts/components/main.tsx
@@ -16,6 +16,7 @@ export default class Main extends React.Component<any, any> {
   themes: string[];
   fileCache: Object;
   startupSound: any;
+  socketController: any;
 
   constructor(props) {
     super(props);
@@ -26,6 +27,7 @@ export default class Main extends React.Component<any, any> {
     ];
 
     const socketController = new SocketController();
+    this.socketController = socketController;
 
     this.fileCache = {};
 
@@ -223,6 +225,7 @@ export default class Main extends React.Component<any, any> {
                 graph={this.state.graph}
                 demo={demo}
                 nodes={demo.nm.nodes}
+                socket={this.socketController}
                 >
               </GraphEditor>
             </div>

--- a/nin/frontend/app/styles/common.less
+++ b/nin/frontend/app/styles/common.less
@@ -598,3 +598,7 @@ svg text.monospaced {
         cursor: pointer;
     }
 }
+
+.graph-editor-line-x {
+  fill: @radical-red;
+}


### PR DESCRIPTION
Now graph edges can be added and removed in a crude first-step
implementation of an editable ui. The plan is to slowly iterate towards
a slick solution over multiple pull requests.

This pull requests disables live watch reloads on res/graph.json. The
idea is that it is loaded from the backend only once, and from then on
the frontend is responsible for editing it, sending graph change events
to the backend for persistance.