### PR TITLE
Repair error messages

### DIFF
--- a/nin/frontend/app/scripts/components/demoplayer.js
+++ b/nin/frontend/app/scripts/components/demoplayer.js
@@ -68,7 +68,13 @@ class DemoPlayer extends React.Component {
       // exit fullscreen
       document.body.classList.remove('fullscreen');
     }
-    this.props.demo.resize();
+    try {
+      this.props.demo.resize();
+    } catch(e) {
+      /* just ignoring any crashes here since they will be caught in the next
+       * render loop anyway, and we have a nicer error formatting setup over
+       * there. */
+    }
     this.resizeOverlay();
   }
 

--- a/nin/frontend/app/scripts/components/main.tsx
+++ b/nin/frontend/app/scripts/components/main.tsx
@@ -40,6 +40,7 @@ export default class Main extends React.Component<any, any> {
     };
 
     demo.music.setVolume(1 - this.state.mute);
+    demo.registerMainComponent(this);
 
     commands.on('playSplashScreen', () => {
       this.startupSound = new Audio();
@@ -185,7 +186,7 @@ export default class Main extends React.Component<any, any> {
         e.name = event.name;
 
         const globalJSErrors = (Object as any).assign({}, this.state.globalJSErrors);
-        globalJSErrors[event.type] = e;
+        globalJSErrors[event.name] = e;
         this.setState({globalJSErrors});
       }
     });

--- a/nin/frontend/app/scripts/demo.js
+++ b/nin/frontend/app/scripts/demo.js
@@ -7,7 +7,6 @@ const demo = bootstrap({
 
 window.demo = demo;
 
-demo.globalJSErrors = demo.globalJSErrors || {};
 var originalLoop = demo.looper.loop;
 var forcedPause = false;
 const stats = [];
@@ -31,6 +30,12 @@ commands.on('toggleStats', () => {
   }
 });
 
+let main;
+
+demo.registerMainComponent = function(mainComponent) {
+  main = mainComponent;
+};
+
 
 demo.looper.loop = function() {
   try {
@@ -47,10 +52,16 @@ demo.looper.loop = function() {
       forcedPause = false;
     }
 
-    delete demo.globalJSErrors.looper;
+    if(main.state.globalJSErrors.looper) {
+      const globalJSErrors = Object.assign({}, main.state.globalJSErrors);
+      delete globalJSErrors.looper;
+      main.setState({globalJSErrors});
+    }
   } catch(e) {
     e.context = "Error during looping of demo";
-    demo.globalJSErrors.looper = e;
+    const globalJSErrors = Object.assign({}, main.state.globalJSErrors);
+    globalJSErrors.looper = e;
+    main.setState({globalJSErrors});
 
     demo.looper.deltaTime += demo.looper.frameLength;
     demo.looper.currentFrame -= 1;


### PR DESCRIPTION
Some of the error message code has been broken for a bit. 1) Error
messages from a web socket load have not been clearing themselves
automatically when the error has been fixed, and 2) error messages from
the looper have not been displayed at all. This commit fixes both of
these regressions.

Auto-clearing:
![](https://i.gyazo.com/0ed0f09225591c83372f3d5cf727933a.gif)

looper errors:
![](https://i.gyazo.com/266455d9fd2067a96cbab6d99b091461.gif)