### PR TITLE
Update to latest Closure compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "glob": "7.0.3",
     "glsl-deparser": "^1.0.0",
     "glsl-parser": "^2.0.0",
-    "google-closure-compiler-js": "^20170409.0.0",
+    "google-closure-compiler-js": "^20170910.0.1",
     "imagemin": "5.3.1",
     "imagemin-jpegtran": "5.0.2",
     "imagemin-zopfli": "5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,9 +1661,9 @@ glsl-tokenizer@^2.0.0:
   dependencies:
     through2 "^0.6.3"
 
-google-closure-compiler-js@^20170409.0.0:
-  version "20170409.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20170409.0.0.tgz#e71063ab2bf26db794732222ec76ba07403df854"
+google-closure-compiler-js@^20170910.0.1:
+  version "20170910.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20170910.0.1.tgz#06c93b215092f4ad57928a8a1b0f129566d2af78"
   dependencies:
     minimist "^1.2.0"
     vinyl "^2.0.1"


### PR DESCRIPTION
Google Closure Compiler has started work on outputting es2015 instead of
only support ES5 output! It is still experimental, and lots of
optimization passes are currently skipped when using it, but this means
they will probably soon support it more and more. They also now default
to running all ES6 code in strict mode.

https://github.com/google/closure-compiler/wiki/Releases