### PR TITLE
Remove destination on Outputs

### DIFF
--- a/nin/dasBoot/NodeManager.js
+++ b/nin/dasBoot/NodeManager.js
@@ -19,17 +19,20 @@ class NodeManager {
   }
 
   insertOrReplaceNode(node) {
-    if(this.nodes[node.id]) {
-      for(var key in this.nodes[node.id].inputs) {
-        if(this.nodes[node.id].inputs[key].source) {
-          node.inputs[key].source = this.nodes[node.id].inputs[key].source;
-          node.inputs[key].source.destination = node.inputs[key];
-        }
-      }
-      for(var key in this.nodes[node.id].outputs) {
-        if(this.nodes[node.id].outputs[key].destination) {
-          node.outputs[key].destination = this.nodes[node.id].outputs[key].destination;
-          node.outputs[key].destination.source = node.outputs[key];
+    const nodeToReplace = this.nodes[node.id];
+    if(nodeToReplace) {
+      for(let key in this.nodes) {
+        const currentNode = this.nodes[key];
+        for(let inputKey in currentNode.inputs) {
+          const input = currentNode.inputs[inputKey];
+          if(input.source && input.source.node === nodeToReplace) {
+            for(let k in nodeToReplace.outputs) {
+              if(nodeToReplace.outputs[k] === input.source) {
+                input.source = node.outputs[k];
+                break;
+              }
+            }
+          }
         }
       }
     }

--- a/nin/frontend/app/scripts/components/editor/GraphEditorInputOutput.js
+++ b/nin/frontend/app/scripts/components/editor/GraphEditorInputOutput.js
@@ -14,7 +14,7 @@ class GraphEditorInputOutput extends React.Component {
         valueType = typeof value;
       }
     }
-    const isConnected = !!(this.props.item.destination || this.props.item.source);
+    const isConnected = !!this.props.item.source;
     return e('g', {
       transform: `translate(${this.props.x}, ${this.props.y}) scale(${1 / this.props.scale})`
     },


### PR DESCRIPTION
A single output can have more than one destination, so we should either
store all or none of them on an output. This commit does the latter.
Practical consequences of this is that we now support proper
live-reloading of nodes that have multiple paths to the root node.