### PR TITLE
Make makefile forward commands to package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: all
 all:
-	yarn install
-	cd nin/frontend && make
+	yarn start
 
 .PHONY: publish
 publish: all

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Expect to render maybe a frame or two per second.
 
 You will need to have node and yarn installed.
 Yarn installation guide is available [here](https://yarnpkg.com/en/docs/install).
-If you already have npm installed you can bootstrap to yarn by running `npm install -g yarn`.
 
 Running `make` in the nin folder will build and compile the entire project.
 Running `npm link` will add nin to your node binaries path, making it available globally.

--- a/README.md
+++ b/README.md
@@ -105,10 +105,9 @@ Expect to render maybe a frame or two per second.
 
 ## Setup
 
-You will need to have node, yarn and webpack installed.
+You will need to have node and yarn installed.
 Yarn installation guide is available [here](https://yarnpkg.com/en/docs/install).
 If you already have npm installed you can bootstrap to yarn by running `npm install -g yarn`.
-Install webpack by running `npm install -g webpack`.
 
 Running `make` in the nin folder will build and compile the entire project.
 Running `npm link` will add nin to your node binaries path, making it available globally.

--- a/nin/frontend/Makefile
+++ b/nin/frontend/Makefile
@@ -1,12 +1,11 @@
 .PHONY: all
 all:
-	yarn install
-	node_modules/.bin/webpack -p
+	yarn start
 
 .PHONY: run
 run:
-	node_modules/.bin/webpack --watch --display-error-details
+	yarn run webpack-watch
 
 .PHONY: lint
 lint:
-	node_modules/.bin/eslint app/scripts
+	yarn lint

--- a/nin/frontend/package.json
+++ b/nin/frontend/package.json
@@ -38,6 +38,8 @@
     "node": ">=4.0.0"
   },
   "scripts": {
+    "start": "yarn install && webpack -p",
+    "webpack-watch": "webpack --watch --display-error-details",
     "lint": "eslint app",
     "fix-lint": "eslint --fix app"
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "node": ">=7.9.0"
   },
   "scripts": {
+    "start": "yarn install && (cd nin/frontend && yarn build)",
     "lint": "cd nin/backend && eslint . || true"
   },
   "bin": {


### PR DESCRIPTION
This way systems without make can run `yarn start` in the root folder instead of having to install make for windows from sourceforge.