### PR TITLE
Add beforeUpdate node hook

### DIFF
--- a/nin/dasBoot/NodeManager.js
+++ b/nin/dasBoot/NodeManager.js
@@ -74,6 +74,15 @@ class NodeManager {
     fn(node);
   }
 
+  beforeUpdate(frame) {
+    if(!this.nodes.root) {
+      return;
+    }
+    this.traverseNodeGraphPostOrderDfs(this.nodes.root, node => {
+      node.beforeUpdate(frame);
+    });
+  }
+
   update(frame) {
     if(!this.nodes.root) {
       return;

--- a/nin/dasBoot/bootstrap.js
+++ b/nin/dasBoot/bootstrap.js
@@ -88,6 +88,7 @@ window['bootstrap'] = function(options) {
 
   demo.update = function(frame) {
     currentFrame = frame;
+    demo.nm.beforeUpdate(frame);
     demo.nm.update(frame);
   };
 
@@ -124,6 +125,7 @@ window['bootstrap'] = function(options) {
 
   demo.looper = createLoop({
     render: demo.render,
+    beforeUpdate: demo.beforeUpdate,
     update: demo.update,
     renderer: demo.renderer,
     music: demo.music

--- a/nin/dasBoot/node.js
+++ b/nin/dasBoot/node.js
@@ -21,6 +21,9 @@ class Node {
   render() {
   }
 
+  beforeUpdate() {
+  }
+
   update() {
   }
 


### PR DESCRIPTION
This is useful for enabling and disabling inputs before update and
render is called. The practical impact of this is that the oft-used
SceneSwitcherNode pattern can properly change scenes so that update is
called on the first frame after the change.