### PR TITLE
Enforce Unix-style endings even in a Windows environment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Reason: The linter gave me a wall of text telling that the line endings were not as expected (LF) in frontend js files