### PR TITLE
Add back ghetto-patching of FRAME_FOR_BEAN et al.

### DIFF
--- a/nin/backend/compile.js
+++ b/nin/backend/compile.js
@@ -160,6 +160,8 @@ async function collect(projectPath, data) {
     'GU=1;' + /* hack to make sure GU exisits from the get-go */
     'BEAN=0;' +
     'BEAT=false;' +
+    'FRAME_FOR_BEAN=function placeholder(){};' +
+    'BEAN_FOR_FRAME=function placeholder(){};' +
     data +
     'var graph = JSON.parse(atob(FILES["res/graph.json"]));' +
     'demo=bootstrap({graph:graph, onprogress: ONPROGRESS, oncomplete: ONCOMPLETE});' +

--- a/nin/backend/compress.js
+++ b/nin/backend/compress.js
@@ -76,6 +76,8 @@ async function compress(projectPath, payload, htmlPreamble, metadata) {
           'GU=1;' + /* hack to make sure GU exisits from the get-go */
           'BEAN=0;' +
           'BEAT=false;' +
+          'FRAME_FOR_BEAN=function placeholder(){};' +
+          'BEAN_FOR_FRAME=function placeholder(){};' +
           '(1,eval)(s);' +
           'var graph = JSON.parse(atob(FILES["res/graph.json"]));' +
           'demo=bootstrap({graph:graph, onprogress: ONPROGRESS, oncomplete: ONCOMPLETE});' +


### PR DESCRIPTION
This is needed to make revision-invite-2018 compile properly, probably
because it references FRAME_FOR_BEAN inside on or more of its render
methods.