### PR TITLE
Add interpolated BEAN number for animation use

### DIFF
--- a/nin/dasBoot/BEATBEAN.js
+++ b/nin/dasBoot/BEATBEAN.js
@@ -26,7 +26,12 @@ const updateBeatBean = function(frame) {
       ((frame + 0.5) / framesPerBEAT) | 0) {
     window.BEAT = true;
   }
-  window.BEAN = (frame + 1.5) / framesPerBEAT | 0;
+  var bean = (frame + 1.5) / framesPerBEAT | 0;
+  window.BEAN = bean;
+
+  var f = (frame - FRAME_FOR_BEAN(bean))
+        / (FRAME_FOR_BEAN(bean+1) - FRAME_FOR_BEAN(bean));
+  window.INTERBEAN = lerp(bean, bean+1, f);
 };
 
 module.exports = {initBeatBean, updateBeatBean};


### PR DESCRIPTION
Adds new global variable INTERBEAN, which is a float that is
interpolated between BEAN numbers, in a linear way between frames.
This can be used to key animations without getting the lower frame rate
of BEAN.

Discussion to be had here: Can we instead change BEAN to have fractional values? The way I see it that would be the preferred option here, but I'm afraid of changing behaviour if people have already relied on it being an integer somewhere.