### PR TITLE
Fully traverse the graph on beforeUpdate

### DIFF
--- a/nin/dasBoot/NodeManager.js
+++ b/nin/dasBoot/NodeManager.js
@@ -61,17 +61,18 @@ class NodeManager {
     }
   }
 
-  traverseNodeGraphPostOrderDfs(node, fn, visitedSet={}) {
+  traverseNodeGraphPostOrderDfs(node, fn, fullTraversal=false, visitedSet={}) {
     if(node.id in visitedSet) {
       return;
     }
     visitedSet[node.id] = true;
     for(var key in node.inputs) {
       var input = node.inputs[key];
-      if(input.source && input.enabled) {
+      if(input.source && (fullTraversal || input.enabled)) {
         this.traverseNodeGraphPostOrderDfs(
             input.source.node,
             fn,
+            fullTraversal,
             visitedSet);
       }
     }
@@ -84,7 +85,7 @@ class NodeManager {
     }
     this.traverseNodeGraphPostOrderDfs(this.nodes.root, node => {
       node.beforeUpdate(frame);
-    });
+    }, true);
   }
 
   update(frame) {


### PR DESCRIPTION
We need to either fully traverse the graph on beforeUpdate, iterate over
all the nodes linearly or DFS prefix-traverse the graph for beforeUpdate
to work properly in some edge cases, I think. This commits adds full
traversal to beforeUpdate.