### PR TITLE
Update closure-compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "glob": "7.0.3",
     "glsl-deparser": "^1.0.0",
     "glsl-parser": "^2.0.0",
-    "google-closure-compiler-js": "^20170910.0.1",
+    "google-closure-compiler-js": "20180610.0.0",
     "imagemin": "5.3.1",
     "imagemin-jpegtran": "5.0.2",
     "imagemin-zopfli": "5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,9 +2019,9 @@ glsl-tokenizer@^2.0.0:
   dependencies:
     through2 "^0.6.3"
 
-google-closure-compiler-js@^20170910.0.1:
-  version "20170910.0.1"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20170910.0.1.tgz#06c93b215092f4ad57928a8a1b0f129566d2af78"
+google-closure-compiler-js@20180610.0.0:
+  version "20180610.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20180610.0.0.tgz#df0dbf39ba3977027db2c1beb244368521c9220b"
   dependencies:
     minimist "^1.2.0"
     vinyl "^2.0.1"


### PR DESCRIPTION
It seems that something broke in the generated code for compiled demos when webpack was updated to version 4, because the syntax it produces when modules are required is different.
This latest version of the closure compiler handles that syntax well though, so with this commit compiling demos seems to work again.