### PR TITLE
Fix beat bean initing

### DIFF
--- a/nin/dasBoot/bootstrap.js
+++ b/nin/dasBoot/bootstrap.js
@@ -54,7 +54,7 @@ window['bootstrap'] = function(options) {
 
   Loader.setRootPath(options.rootPath || '');
 
-  initBeatBean();
+  window.initBeatBean();
 
   demo.nm = new NodeManager(demo);
 
@@ -150,7 +150,7 @@ window['bootstrap'] = function(options) {
     demo.looper.oldTime = time;
     demo.looper.deltaTime = 0;
     demo.looper.currentFrame = frame;
-    updateBeatBean(frame);
+    window.updateBeatBean(frame);
     demo.nm.jumpToFrame(frame);
     demo.update(frame);
     demo.render(demo.renderer, 0);


### PR DESCRIPTION
After upgrading webpack, the generated code in dasboot.js changed for
the cases where we do:
```
const {functionA, functionB} = require('./module');
window.functionA = functionA;
window.functionB = functionB;
```

When the closure compiler sees this during compilation of the demo, it
derps and doesn't recognize that we might actually use the local
variable `functionA` inside bootstrap.js directly, and removes the
variable.

Updating the code in this file to read the function from the window
scope explicitly works as a hack to make compilation work again.

In the future, we may fix this properly by removing everything from
window scope and using modules fully.