### PR TITLE
Adds package-lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ Thumbs.db
 # NPM packages folder.
 node_modules/
 
+# Other package file
+package-lock.json
+
 # Brunch folder for temporary files.
 tmp/
 


### PR DESCRIPTION
Nin uses yarn, so the package-lock file from npm is not needed. This will stop it from being checked in at a later stage.