### PR TITLE
Use beforeUpdate instead of update by default in SceneSwitcherNode.

### DIFF
--- a/nin/backend/blank-project/src/SceneSwitcherNode.js
+++ b/nin/backend/blank-project/src/SceneSwitcherNode.js
@@ -24,7 +24,11 @@
       }
 
       selectedScene.enabled = true;
-      this.outputs.render.setValue(selectedScene.getValue());
+      this.selectedScene = selectedScene;
+    }
+
+    render() {
+      this.outputs.render.setValue(this.selectedScene.getValue());
     }
   }
 

--- a/nin/backend/blank-project/src/SceneSwitcherNode.js
+++ b/nin/backend/blank-project/src/SceneSwitcherNode.js
@@ -12,7 +12,7 @@
       });
     }
 
-    update() {
+    beforeUpdate() {
       this.inputs.A.enabled = false;
       this.inputs.B.enabled = false;
 


### PR DESCRIPTION
This fixes a graph rendering delay issue.