### PR TITLE
Try new method of comparing environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ deploy:
   api_key:
     secure: iWwXLzno47upqZ0qETbuc+sWEDf9drr/KYulsjWJMCuTdeWj4HuF4NcMSENR43ngeEBO34+NxiAjC0yKe+qPJ6bmq06fYPjobPHUhI9tfWRUsuxxkxhZUnTsR2FaOz7vVe1GTECcqKtR1OAeJH7IPWvanKHNMOyXjUrvSKWPtmo=
   on:
-    condition: env(PACKAGE_VERSION) != env(LATEST_TAG)
+    condition: "$PACKAGE_VERSION" != "$LATEST_TAG"


### PR DESCRIPTION
The method tried in #509 looks like it crashed. Here's trying wrapping the previous version of comparing two environment variables in `"` to ensure they are compared as strings.