### PR TITLE
Fix syntax error in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ deploy:
   api_key:
     secure: iWwXLzno47upqZ0qETbuc+sWEDf9drr/KYulsjWJMCuTdeWj4HuF4NcMSENR43ngeEBO34+NxiAjC0yKe+qPJ6bmq06fYPjobPHUhI9tfWRUsuxxkxhZUnTsR2FaOz7vVe1GTECcqKtR1OAeJH7IPWvanKHNMOyXjUrvSKWPtmo=
   on:
-    condition: "$PACKAGE_VERSION" != "$LATEST_TAG"
+    branch: master
+    condition: "$PACKAGE_VERSION != $LATEST_TAG"


### PR DESCRIPTION
I think I _finally_ understood the docs on this feature now:

> condition: deploy when a single bash condition evaluates to true. This
must be a string value, and is equivalent to if [[ <condition> ]]; then
<deploy>; fi. For example, $CC = gcc.

The docs were inconsistent on whether or not the whole thing was wrapped
in strings. I think now, that if it's all in quotes it will be executed
at runtime as a bash if statement. Otherwise, it is evaluated by travis
and the _result_ is put as the condition in bash. So for instance,
travis can evaluate something to "true" and then put the string "true"
in if [[ true ]]; then

Hopefulle this should do the trick, and for good measure I included a
guard to ensure this only runs on master, now that I might have
overridden the conditions for when deploy runs.