### PR TITLE
Move travis tagging to after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 script:
 - cd nin/backend && ../../node_modules/.bin/eslint .
 - cd ../frontend && make lint
-before_deploy:
+after_success:
   - export PACKAGE_VERSION=$(node -p "require('./package.json').version")
   - export LATEST_TAG=$(git tag | sed 's/^v\(.*\)/\1/' | sort -g | tail -n 1)
   - git config --local user.name "Travis"


### PR DESCRIPTION
FINALLY! I think I've already said this, but _now_ I know why travis
deploy to npm didn't work. The `before_deploy` step is _not_ an
appropriate place to set up variables that are needed to check if we
want to deploy. It seems like the life cycle goes something like this:
- install
- script
- after_success
- check the condition blocks of any deploy stages
- for each deploy stage that we _now_ know that we're going to run, run
the before_deploy stage
- actually run deploy
- run after_deploy

Now all that's left to be seen after this is merged, is if travis can
manage to push this tag back to github or not.