### PR TITLE
Upgrade typescript from 2.4 to 4.0

### DIFF
--- a/nin/frontend/package.json
+++ b/nin/frontend/package.json
@@ -30,7 +30,7 @@
     "ng-annotate-loader": "^0.2.0",
     "source-map-loader": "^0.2.1",
     "style-loader": "^0.14.0",
-    "typescript": "^2.4.1",
+    "typescript": "^4.0.7",
     "webpack": "^2.2.1"
   },
   "engines": {


### PR DESCRIPTION
Context: When I ran `npm start` to build nin on my Windows computer, I eventually got this error message:

```
ERROR in [at-loader] ./node_modules/@types/node/index.d.ts:35:1
    TS1084: Invalid 'reference' directive syntax.
```

Upgrading to typescript 4 helped